### PR TITLE
fix: NameError when importing SingleFileSnapshotExtension

### DIFF
--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -30,7 +30,7 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         *,
         exclude: Optional["PropertyFilter"] = None,
         matcher: Optional["PropertyMatcher"] = None,
-    ) -> SerializedData:
+    ) -> "SerializedData":
         return bytes(data)
 
     def get_snapshot_name(self, *, index: int = 0) -> str:


### PR DESCRIPTION
## Description

Fixes the following issue:

If you try  to import `SingleFileSnapshotExtension` it will raise `NameError: name 'SerializedData' is not defined` because SerializedData is only imported if type checking and the return type annotation was not quoted.

Example:
```
>>> from syrupy.extensions.single_file import SingleFileSnapshotExtension
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jocke/projects/syrupy/src/syrupy/extensions/single_file.py", line 26, in <module>
    class SingleFileSnapshotExtension(AbstractSyrupyExtension):
  File "/Users/jocke/projects/syrupy/src/syrupy/extensions/single_file.py", line 33, in SingleFileSnapshotExtension
    ) -> SerializedData:
NameError: name 'SerializedData' is not defined
```
