### PR TITLE
Decouple different snapshot functionality

### DIFF
--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -374,7 +374,7 @@ class SnapshotAssertion:
     ) -> Tuple[Optional["SerializableData"], bool]:
         try:
             return (
-                self.extension.read_snapshot(
+                self.storage.read_snapshot(
                     test_location=self.test_location,
                     index=index,
                     session_id=str(id(self.session)),

--- a/tests/syrupy/extensions/__snapshots__/test_single_file_amber/test_single_file_amber.1.raw
+++ b/tests/syrupy/extensions/__snapshots__/test_single_file_amber/test_single_file_amber.1.raw
@@ -1,0 +1,3 @@
+dict({
+  'fruit': 'orange',
+})

--- a/tests/syrupy/extensions/__snapshots__/test_single_file_amber/test_single_file_amber.raw
+++ b/tests/syrupy/extensions/__snapshots__/test_single_file_amber/test_single_file_amber.raw
@@ -1,0 +1,3 @@
+dict({
+  'fruit': 'apple',
+})

--- a/tests/syrupy/extensions/test_single_file_amber.py
+++ b/tests/syrupy/extensions/test_single_file_amber.py
@@ -1,0 +1,16 @@
+from syrupy.extensions.amber import AmberSnapshotExtension
+from syrupy.extensions.single_file import (
+    SingleFileSnapshotExtension,
+    WriteMode,
+)
+
+
+class SingleTextFileExtension(SingleFileSnapshotExtension):
+    _write_mode = WriteMode.TEXT
+
+
+def test_single_file_amber(snapshot):
+    storage = SingleTextFileExtension()
+    serializer = AmberSnapshotExtension()
+    assert {"fruit": "apple"} == snapshot(storage=storage, serializer=serializer)
+    assert {"fruit": "orange"} == snapshot(storage=storage, serializer=serializer)


### PR DESCRIPTION
Decouple different snapshot functionality

## Description

e.g. The plugin architecture is defined with multiple subparts. This plugin allows implementing those separately - e.g. you can use a different serializer from comparator.

## Related Issues

- Addresses use-case mentioned in #749, using default serializer but separate per-test snapshot files.


## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [ ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
