### PR TITLE
feat: Support passing arbitrary arguments/context to custom extensions (Issue #700)

### DIFF
--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -264,6 +264,7 @@ class SnapshotAssertion:
         extension_class: Optional[Type["AbstractSyrupyExtension"]] = None,
         matcher: Optional["PropertyMatcher"] = None,
         name: Optional["SnapshotIndex"] = None,
+        **kwargs: Any,
     ) -> "SnapshotAssertion":
         """
         Modifies assertion instance options

--- a/src/syrupy/extensions/amber/__init__.py
+++ b/src/syrupy/extensions/amber/__init__.py
@@ -47,7 +47,7 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
         else:
             Path(snapshot_location).unlink()
 
-    def _read_snapshot_collection(self, snapshot_location: str) -> "SnapshotCollection":
+    def _read_snapshot_collection(self, snapshot_location: str, **kwargs: Any) -> "SnapshotCollection":
         return self.serializer_class.read_file(snapshot_location)
 
     @classmethod
@@ -72,7 +72,7 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
 
     @classmethod
     def _write_snapshot_collection(
-        cls, *, snapshot_collection: "SnapshotCollection"
+        cls, *, snapshot_collection: "SnapshotCollection", **kwargs: Any
     ) -> None:
         cls.serializer_class.write_file(snapshot_collection, merge=True)
 

--- a/src/syrupy/extensions/amber/__init__.py
+++ b/src/syrupy/extensions/amber/__init__.py
@@ -47,7 +47,9 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
         else:
             Path(snapshot_location).unlink()
 
-    def _read_snapshot_collection(self, snapshot_location: str, **kwargs: Any) -> "SnapshotCollection":
+    def _read_snapshot_collection(
+        self, snapshot_location: str, **kwargs: Any
+    ) -> "SnapshotCollection":
         return self.serializer_class.read_file(snapshot_location)
 
     @classmethod

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -8,6 +8,7 @@ from itertools import zip_longest
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Dict,
     Iterator,
@@ -15,7 +16,6 @@ from typing import (
     Optional,
     Set,
     Tuple,
-    Any,
 )
 
 from syrupy.constants import (

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -119,7 +119,7 @@ class SnapshotCollectionStorage(ABC):
         for filepath in walk_snapshot_dir(self.dirname(test_location=test_location)):
             if self.is_snapshot_location(location=filepath):
                 snapshot_collection = self._read_snapshot_collection(
-                    snapshot_location=filepath
+                    snapshot_location=filepath, **kwargs
                 )
                 if not snapshot_collection.has_snapshots:
                     snapshot_collection = SnapshotEmptyCollection(location=filepath)
@@ -136,6 +136,7 @@ class SnapshotCollectionStorage(ABC):
         test_location: "PyTestLocation",
         index: "SnapshotIndex",
         session_id: str,
+        **kwargs: Any,
     ) -> "SerializedData":
         """
         This method is _final_, do not override. You can override
@@ -147,6 +148,7 @@ class SnapshotCollectionStorage(ABC):
             snapshot_location=snapshot_location,
             snapshot_name=snapshot_name,
             session_id=session_id,
+            **kwargs,
         )
         if snapshot_data is None:
             raise SnapshotDoesNotExist()
@@ -227,7 +229,12 @@ class SnapshotCollectionStorage(ABC):
 
     @abstractmethod
     def _read_snapshot_data_from_location(
-        self, *, snapshot_location: str, snapshot_name: str, session_id: str
+        self,
+        *,
+        snapshot_location: str,
+        snapshot_name: str,
+        session_id: str,
+        **kwargs: Any,
     ) -> Optional["SerializedData"]:
         """
         Get only the snapshot data from location for assertion

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -15,6 +15,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Any,
 )
 
 from syrupy.constants import (
@@ -67,6 +68,7 @@ class SnapshotSerializer(ABC):
         exclude: Optional["PropertyFilter"] = None,
         include: Optional["PropertyFilter"] = None,
         matcher: Optional["PropertyMatcher"] = None,
+        **kwargs: Any,
     ) -> "SerializedData":
         """
         Serializes a python object / data structure into a string
@@ -108,7 +110,7 @@ class SnapshotCollectionStorage(ABC):
         return location.endswith(self._file_extension)
 
     def discover_snapshots(
-        self, *, test_location: "PyTestLocation"
+        self, *, test_location: "PyTestLocation", **kwargs: Any
     ) -> "SnapshotCollections":
         """
         Returns all snapshot collections in test site
@@ -216,7 +218,7 @@ class SnapshotCollectionStorage(ABC):
 
     @abstractmethod
     def _read_snapshot_collection(
-        self, *, snapshot_location: str
+        self, *, snapshot_location: str, **kwargs: Any
     ) -> "SnapshotCollection":
         """
         Read the snapshot location and construct a snapshot collection object
@@ -235,7 +237,7 @@ class SnapshotCollectionStorage(ABC):
     @classmethod
     @abstractmethod
     def _write_snapshot_collection(
-        cls, *, snapshot_collection: "SnapshotCollection"
+        cls, *, snapshot_collection: "SnapshotCollection", **kwargs: Any
     ) -> None:
         """
         Adds the snapshot data to the snapshots in collection location
@@ -243,7 +245,9 @@ class SnapshotCollectionStorage(ABC):
         raise NotImplementedError
 
     @classmethod
-    def dirname(cls, *, test_location: "PyTestLocation") -> str:
+    def dirname(
+        cls, *, test_location: "PyTestLocation", **kwargs: Any
+    ) -> str:
         test_dir = Path(test_location.filepath).parent
         return str(test_dir.joinpath(SNAPSHOT_DIRNAME))
 
@@ -259,7 +263,10 @@ class SnapshotReporter(ABC):
     _context_line_count = 1
 
     def diff_snapshots(
-        self, serialized_data: "SerializedData", snapshot_data: "SerializedData"
+        self,
+        serialized_data: "SerializedData",
+        snapshot_data: "SerializedData",
+        **kwargs: Any,
     ) -> "SerializedData":
         env = {DISABLE_COLOR_ENV_VAR: "true"}
         attrs = {"_context_line_count": 0}
@@ -267,7 +274,10 @@ class SnapshotReporter(ABC):
             return "\n".join(self.diff_lines(serialized_data, snapshot_data))
 
     def diff_lines(
-        self, serialized_data: "SerializedData", snapshot_data: "SerializedData"
+        self,
+        serialized_data: "SerializedData",
+        snapshot_data: "SerializedData",
+        **kwargs: Any,
     ) -> Iterator[str]:
         for line in self.__diff_lines(str(snapshot_data), str(serialized_data)):
             yield reset(line)
@@ -407,6 +417,7 @@ class SnapshotComparator:
         *,
         serialized_data: "SerializableData",
         snapshot_data: "SerializableData",
+        **kwargs: Any,
     ) -> bool:
         """
         Compares serialized data and snapshot data and returns

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -245,9 +245,7 @@ class SnapshotCollectionStorage(ABC):
         raise NotImplementedError
 
     @classmethod
-    def dirname(
-        cls, *, test_location: "PyTestLocation", **kwargs: Any
-    ) -> str:
+    def dirname(cls, *, test_location: "PyTestLocation", **kwargs: Any) -> str:
         test_dir = Path(test_location.filepath).parent
         return str(test_dir.joinpath(SNAPSHOT_DIRNAME))
 

--- a/src/syrupy/extensions/json/__init__.py
+++ b/src/syrupy/extensions/json/__init__.py
@@ -145,6 +145,7 @@ class JSONSnapshotExtension(SingleFileSnapshotExtension):
         exclude: Optional["PropertyFilter"] = None,
         include: Optional["PropertyFilter"] = None,
         matcher: Optional["PropertyMatcher"] = None,
+        **kwargs: Any,
     ) -> "SerializedData":
         data = self._filter(
             data=data,

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -1,13 +1,7 @@
 from enum import Enum
 from gettext import gettext
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Optional,
-    Set,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Optional, Set, Type, Union, Dict, Any
 from unicodedata import category
 
 from syrupy.constants import TEXT_ENCODING
@@ -49,6 +43,7 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         exclude: Optional["PropertyFilter"] = None,
         include: Optional["PropertyFilter"] = None,
         matcher: Optional["PropertyMatcher"] = None,
+        **kwargs: Any,
     ) -> "SerializedData":
         return self.get_supported_dataclass()(data)
 
@@ -74,12 +69,17 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         return cls.get_snapshot_name(test_location=test_location, index=index)
 
     @classmethod
-    def dirname(cls, *, test_location: "PyTestLocation") -> str:
+    def dirname(
+        cls, *, test_location: "PyTestLocation", **kwargs: Any
+    ) -> str:
         original_dirname = AbstractSyrupyExtension.dirname(test_location=test_location)
         return str(Path(original_dirname).joinpath(test_location.basename))
 
     def _read_snapshot_collection(
-        self, *, snapshot_location: str
+        self,
+        *,
+        snapshot_location: str,
+        **kwargs: Any,
     ) -> "SnapshotCollection":
         file_ext_len = len(self._file_extension) + 1 if self._file_extension else 0
         filename_wo_ext = snapshot_location[:-file_ext_len]
@@ -116,7 +116,10 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
 
     @classmethod
     def _write_snapshot_collection(
-        cls, *, snapshot_collection: "SnapshotCollection"
+        cls,
+        *,
+        snapshot_collection: "SnapshotCollection",
+        **kwargs: Any,
     ) -> None:
         filepath, data = (
             snapshot_collection.location,

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from gettext import gettext
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Set, Type, Union, Dict, Any
+from typing import TYPE_CHECKING, Optional, Set, Type, Union, Any
 from unicodedata import category
 
 from syrupy.constants import TEXT_ENCODING
@@ -69,9 +69,7 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         return cls.get_snapshot_name(test_location=test_location, index=index)
 
     @classmethod
-    def dirname(
-        cls, *, test_location: "PyTestLocation", **kwargs: Any
-    ) -> str:
+    def dirname(cls, *, test_location: "PyTestLocation", **kwargs: Any) -> str:
         original_dirname = AbstractSyrupyExtension.dirname(test_location=test_location)
         return str(Path(original_dirname).joinpath(test_location.basename))
 

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -1,7 +1,14 @@
 from enum import Enum
 from gettext import gettext
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Set, Type, Union, Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    Set,
+    Type,
+    Union,
+)
 from unicodedata import category
 
 from syrupy.constants import TEXT_ENCODING


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->
Related to https://github.com/tophat/syrupy/issues/687 and https://github.com/tophat/syrupy/issues/700.

Allowing custom `**kwargs` to custom extension classes.

e.g. This PR refactors the X submodule, applying Y's algorithm to improve Z by K percent.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->


- Closes https://github.com/tophat/syrupy/issues/700. 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [ ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
