### PR TITLE
refactor: scaffolding to support custom context in extensions

### DIFF
--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -80,7 +80,10 @@ class SnapshotCollectionStorage(ABC):
 
     @classmethod
     def get_snapshot_name(
-        cls, *, test_location: "PyTestLocation", index: "SnapshotIndex" = 0
+        cls,
+        *,
+        test_location: "PyTestLocation",
+        index: "SnapshotIndex" = 0,
     ) -> str:
         """Get the snapshot name for the assertion index in a test location"""
         index_suffix = ""
@@ -225,7 +228,11 @@ class SnapshotCollectionStorage(ABC):
 
     @abstractmethod
     def _read_snapshot_data_from_location(
-        self, *, snapshot_location: str, snapshot_name: str, session_id: str
+        self,
+        *,
+        snapshot_location: str,
+        snapshot_name: str,
+        session_id: str,
     ) -> Optional["SerializedData"]:
         """
         Get only the snapshot data from location for assertion
@@ -259,7 +266,9 @@ class SnapshotReporter(ABC):
     _context_line_count = 1
 
     def diff_snapshots(
-        self, serialized_data: "SerializedData", snapshot_data: "SerializedData"
+        self,
+        serialized_data: "SerializedData",
+        snapshot_data: "SerializedData",
     ) -> "SerializedData":
         env = {DISABLE_COLOR_ENV_VAR: "true"}
         attrs = {"_context_line_count": 0}
@@ -267,7 +276,9 @@ class SnapshotReporter(ABC):
             return "\n".join(self.diff_lines(serialized_data, snapshot_data))
 
     def diff_lines(
-        self, serialized_data: "SerializedData", snapshot_data: "SerializedData"
+        self,
+        serialized_data: "SerializedData",
+        snapshot_data: "SerializedData",
     ) -> Iterator[str]:
         for line in self.__diff_lines(str(snapshot_data), str(serialized_data)):
             yield reset(line)

--- a/src/syrupy/extensions/json/__init__.py
+++ b/src/syrupy/extensions/json/__init__.py
@@ -145,6 +145,7 @@ class JSONSnapshotExtension(SingleFileSnapshotExtension):
         exclude: Optional["PropertyFilter"] = None,
         include: Optional["PropertyFilter"] = None,
         matcher: Optional["PropertyMatcher"] = None,
+        **kwargs: Any,
     ) -> "SerializedData":
         data = self._filter(
             data=data,

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -54,7 +54,10 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
 
     @classmethod
     def get_snapshot_name(
-        cls, *, test_location: "PyTestLocation", index: "SnapshotIndex" = 0
+        cls,
+        *,
+        test_location: "PyTestLocation",
+        index: "SnapshotIndex" = 0,
     ) -> str:
         return cls.__clean_filename(
             AbstractSyrupyExtension.get_snapshot_name(
@@ -79,7 +82,9 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         return str(Path(original_dirname).joinpath(test_location.basename))
 
     def _read_snapshot_collection(
-        self, *, snapshot_location: str
+        self,
+        *,
+        snapshot_location: str,
     ) -> "SnapshotCollection":
         file_ext_len = len(self._file_extension) + 1 if self._file_extension else 0
         filename_wo_ext = snapshot_location[:-file_ext_len]
@@ -90,7 +95,11 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         return snapshot_collection
 
     def _read_snapshot_data_from_location(
-        self, *, snapshot_location: str, snapshot_name: str, session_id: str
+        self,
+        *,
+        snapshot_location: str,
+        snapshot_name: str,
+        session_id: str,
     ) -> Optional["SerializableData"]:
         try:
             with open(
@@ -116,7 +125,9 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
 
     @classmethod
     def _write_snapshot_collection(
-        cls, *, snapshot_collection: "SnapshotCollection"
+        cls,
+        *,
+        snapshot_collection: "SnapshotCollection",
     ) -> None:
         filepath, data = (
             snapshot_collection.location,

--- a/tests/examples/test_custom_snapshot_name.py
+++ b/tests/examples/test_custom_snapshot_name.py
@@ -1,6 +1,8 @@
 """
 Example: Custom Snapshot Name
 """
+from typing import Any
+
 import pytest
 
 from syrupy.extensions.amber import AmberSnapshotExtension
@@ -11,10 +13,10 @@ from syrupy.types import SnapshotIndex
 class CanadianNameExtension(AmberSnapshotExtension):
     @classmethod
     def get_snapshot_name(
-        cls, *, test_location: "PyTestLocation", index: "SnapshotIndex"
+        cls, *, test_location: "PyTestLocation", index: "SnapshotIndex", **kwargs: Any
     ) -> str:
         original_name = AmberSnapshotExtension.get_snapshot_name(
-            test_location=test_location, index=index
+            test_location=test_location, index=index, **kwargs
         )
         return f"{original_name}🇨🇦"
 


### PR DESCRIPTION
NOTE: Since syrupy v4 migrated from instance methods to classmethods, this new context is not actual usable. This lays the groundwork for a switch back to instance methods though (if we continue along this path).

Related to https://github.com/tophat/syrupy/pull/814, this PR lays the groundwork to switch back to instance-based extensions (reverting an earlier decision to move to class methods for easier pytest-xdist compatibility).