### PR TITLE
fix: ignore unused snapshots for skipped test

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -146,14 +146,15 @@ def pytest_collection_finish(session: Any) -> None:
     session.config._syrupy.select_items(session.items)
 
 
-def pytest_runtest_logfinish(nodeid: str) -> None:
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     """
-    At the end of running the runtest protocol for a single item.
-    https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_runtest_logfinish
+    After each of the setup, call and teardown runtest phases of an item.
+    https://docs.pytest.org/en/8.0.x/reference/reference.html#pytest.hookspec.pytest_runtest_logreport
     """
     global _syrupy
-    if _syrupy:
-        _syrupy.ran_item(nodeid)
+    # The outcome will be passed in the teardown phase even if skipped
+    if _syrupy and report.when != "teardown":
+        _syrupy.ran_item(report.nodeid, report.outcome)
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/tests/integration/test_snapshot_skipped.py
+++ b/tests/integration/test_snapshot_skipped.py
@@ -1,0 +1,74 @@
+import pytest
+
+
+@pytest.fixture
+def testcases():
+    return {
+        "used": (
+            """
+            def test_used(snapshot):
+                assert snapshot == 'used'
+            """
+        ),
+        "raise-skipped": (
+            """
+            import pytest
+            def test_skipped(snapshot):
+                pytest.skip("Skipping...")
+                assert snapshot == 'unused'
+            """
+        ),
+        "mark-skipped": (
+            """
+            import pytest
+            @pytest.mark.skip
+            def test_skipped(snapshot):
+                assert snapshot == 'unused'
+            """
+        ),
+        "not-skipped": (
+            """
+            def test_skipped(snapshot):
+                assert snapshot == 'unused'
+            """
+        ),
+    }
+
+
+@pytest.fixture
+def run_testcases(testdir, testcases):
+    pyfile_content = "\n\n".join([testcases["used"], testcases["not-skipped"]])
+    testdir.makepyfile(test_file=pyfile_content)
+    result = testdir.runpytest("-v", "--snapshot-update")
+    result.stdout.re_match_lines(r"2 snapshots generated\.")
+    return testdir, testcases
+
+
+def test_mark_skipped_snapshots(run_testcases):
+    testdir, testcases = run_testcases
+    pyfile_content = "\n\n".join([testcases["used"], testcases["mark-skipped"]])
+    testdir.makepyfile(test_file=pyfile_content)
+
+    result = testdir.runpytest("-v")
+    result.stdout.re_match_lines(r"1 snapshot passed\.$")
+    assert result.ret == 0
+
+
+def test_raise_skipped_snapshots(run_testcases):
+    testdir, testcases = run_testcases
+    pyfile_content = "\n\n".join([testcases["used"], testcases["raise-skipped"]])
+    testdir.makepyfile(test_file=pyfile_content)
+
+    result = testdir.runpytest("-v")
+    result.stdout.re_match_lines(r"1 snapshot passed\.$")
+    assert result.ret == 0
+
+
+def test_skipped_snapshots_update(run_testcases):
+    testdir, testcases = run_testcases
+    pyfile_content = "\n\n".join([testcases["used"], testcases["raise-skipped"]])
+    testdir.makepyfile(test_file=pyfile_content)
+
+    result = testdir.runpytest("-v", "--snapshot-update")
+    result.stdout.re_match_lines(r"1 snapshot passed\.$")
+    assert result.ret == 0


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

This PR tracks the skipped tests and don't mark a snapshot as unused if the corresponding test is skipped.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #787 
- Closes #842

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No comments.
