### PR TITLE
feat: Added a new CLI flag: --snapshot-patch-pycharm-diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ Both options will generate equivalent snapshots but the latter is only viable wh
 These are the cli options exposed to `pytest` by the plugin.
 
 | Option                         | Description                                                                                                                    | Default                                                                                                      |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| ------------------------------ |--------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
 | `--snapshot-update`            | Snapshots will be updated to match assertions and unused snapshots will be deleted.                                            | `False`                                                                                                      |
 | `--snapshot-details`           | Includes details of unused snapshots (test name and snapshot location) in the final report.                                    | `False`                                                                                                      |
 | `--snapshot-warn-unused`       | Prints a warning on unused snapshots rather than fail the test suite.                                                          | `False`                                                                                                      |
 | `--snapshot-default-extension` | Use to change the default snapshot extension class.                                                                            | [AmberSnapshotExtension](https://github.com/syrupy-project/syrupy/blob/main/src/syrupy/extensions/amber/__init__.py) |
 | `--snapshot-no-colors`         | Disable test results output highlighting. Equivalent to setting the environment variables `ANSI_COLORS_DISABLED` or `NO_COLOR` | Disabled by default if not in terminal.                                                                      |
+| `--snapshot-patch-pycharm-diff`| Override Pycharm's default diffs viewer when looking at snapshot diffs. More information in [Using Syrupy from Pycharm]        | `False`                                                                                                      |
 
 ### Assertion Options
 
@@ -469,6 +470,21 @@ The generated snapshot:
 - [Custom comparator](https://github.com/syrupy-project/syrupy/tree/main/tests/integration/test_custom_comparator.py)
 - [JPEG image extension](https://github.com/syrupy-project/syrupy/tree/main/tests/examples/test_custom_image_extension.py)
 - [Built-in image extensions](https://github.com/syrupy-project/syrupy/blob/main/tests/syrupy/extensions/image/test_image_svg.py)
+
+### Viewing Snapshot Diffs in Pycharm IDEs
+Pycharm IDEs come with a built-in tool that helps you to more easily identify differences between the expected result and the actual result in a test.
+However, this tool does not play nicely with syrupy snapshots by default.
+
+Fortunately, Syrupy comes with a runtime flag that will extend Pycharm's default behavior to work nicely with snapshots.
+Pass the `--snapshot-patch-pycharm-diff` flag in your pytest run configuration or create a `pytest.ini` in your project with the following content:
+```ini
+[pytest]
+addopts = --snapshot-patch-pycharm-diff
+
+```
+
+Now you will be able to see snapshot diffs more easily.
+
 
 ## Uninstalling
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ These are the cli options exposed to `pytest` by the plugin.
 | `--snapshot-warn-unused`       | Prints a warning on unused snapshots rather than fail the test suite.                                                          | `False`                                                                                                      |
 | `--snapshot-default-extension` | Use to change the default snapshot extension class.                                                                            | [AmberSnapshotExtension](https://github.com/syrupy-project/syrupy/blob/main/src/syrupy/extensions/amber/__init__.py) |
 | `--snapshot-no-colors`         | Disable test results output highlighting. Equivalent to setting the environment variables `ANSI_COLORS_DISABLED` or `NO_COLOR` | Disabled by default if not in terminal.                                                                      |
-| `--snapshot-patch-pycharm-diff`| Override Pycharm's default diffs viewer when looking at snapshot diffs. More information in [Using Syrupy from Pycharm]        | `False`                                                                                                      |
+| `--snapshot-patch-pycharm-diff`| Override PyCharm's default diffs viewer when looking at snapshot diffs. See [IDE Integrations](#ide-integrations)        | `False`                                                                                                      |
 
 ### Assertion Options
 
@@ -471,20 +471,20 @@ The generated snapshot:
 - [JPEG image extension](https://github.com/syrupy-project/syrupy/tree/main/tests/examples/test_custom_image_extension.py)
 - [Built-in image extensions](https://github.com/syrupy-project/syrupy/blob/main/tests/syrupy/extensions/image/test_image_svg.py)
 
-### Viewing Snapshot Diffs in Pycharm IDEs
-Pycharm IDEs come with a built-in tool that helps you to more easily identify differences between the expected result and the actual result in a test.
-However, this tool does not play nicely with syrupy snapshots by default.
+## IDE Integrations
 
-Fortunately, Syrupy comes with a runtime flag that will extend Pycharm's default behavior to work nicely with snapshots.
-Pass the `--snapshot-patch-pycharm-diff` flag in your pytest run configuration or create a `pytest.ini` in your project with the following content:
+### PyCharm
+
+The [PyCharm](https://www.jetbrains.com/pycharm/) IDE comes with a built-in tool for visualizing differences between expected and actual results in a test. To properly render Syrupy snapshots in the PyCharm diff viewer, we need to apply a patch to the diff viewer library. To do this, use the `--snapshot-patch-pycharm-diff` flag, e.g.:
+
+In your `pytest.ini`:
+
 ```ini
 [pytest]
 addopts = --snapshot-patch-pycharm-diff
-
 ```
 
-Now you will be able to see snapshot diffs more easily.
-
+See [#675](https://github.com/syrupy-project/syrupy/issues/675) for the original issue.
 
 ## Uninstalling
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -1,10 +1,16 @@
 import argparse
 import sys
-from functools import lru_cache
+import warnings
+from functools import (
+    lru_cache,
+    wraps,
+)
 from gettext import gettext
+from inspect import signature
 from typing import (
     Any,
     ContextManager,
+    Iterable,
     List,
     Optional,
 )
@@ -84,6 +90,13 @@ def pytest_addoption(parser: Any) -> None:
         default=not sys.stdout.isatty(),
         dest="no_colors",
         help="Disable test results output highlighting",
+    )
+    group.addoption(
+        "--snapshot-patch-pycharm-diff",
+        action="store_true",
+        default=False,
+        dest="patch_pycharm_diff",
+        help="Patch Pycharm diff",
     )
 
 
@@ -192,3 +205,66 @@ def snapshot(request: Any) -> "SnapshotAssertion":
         test_location=PyTestLocation(request.node),
         session=request.session.config._syrupy,
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _patch_pycharm_diff_viewer_for_snapshots(request: Any) -> Iterable[None]:
+    if not request.config.option.patch_pycharm_diff:
+        yield
+        return
+
+    try:
+        from teamcity.diff_tools import EqualsAssertionError  # type: ignore
+    except ImportError:
+        warnings.warn(
+            "Pycharm's diff tools have failed to be imported. "
+            "Snapshot diffs will not be patched.",
+            stacklevel=2,
+        )
+        yield
+        return
+
+    old_init = EqualsAssertionError.__init__
+    old_init_signature = signature(old_init)
+
+    @wraps(old_init)
+    def new_init(self: EqualsAssertionError, *args: Any, **kwargs: Any) -> None:
+
+        # Extract the __init__ arguments as originally passed in order to
+        # process them later
+        parameters = old_init_signature.bind(self, *args, **kwargs)
+        parameters.apply_defaults()
+        expected = parameters.arguments["expected"]
+        actual = parameters.arguments["actual"]
+        real_exception = parameters.arguments["real_exception"]
+
+        if isinstance(expected, SnapshotAssertion):
+            snapshot = expected
+        elif isinstance(actual, SnapshotAssertion):
+            snapshot = actual
+        else:
+            snapshot = None
+
+        old_init(self, *args, **kwargs)
+
+        # No snapshot was involved in the assertion. Let the old logic do its
+        # thing.
+        if snapshot is None:
+            return
+
+        # Although a snapshot was involved in the assertion, it seems the error
+        # was a result of a non-assertion exception (Ex. `assert 1/0`).
+        # Therefore, We will not do anything here either.
+        if real_exception is not None:
+            return
+
+        assertion_result = snapshot.executions[snapshot.num_executions - 1]
+        if assertion_result.exception is not None:
+            return
+
+        self.expected = str(assertion_result.recalled_data)
+        self.actual = str(assertion_result.asserted_data)
+
+    EqualsAssertionError.__init__ = new_init
+    yield
+    EqualsAssertionError.__init__ = old_init

--- a/src/syrupy/patches/pycharm_diff.py
+++ b/src/syrupy/patches/pycharm_diff.py
@@ -1,0 +1,76 @@
+import warnings
+from contextlib import contextmanager
+from functools import wraps
+from inspect import signature
+from typing import (
+    Any,
+    Iterator,
+)
+
+from syrupy.assertion import SnapshotAssertion
+
+
+@contextmanager
+def patch_pycharm_diff() -> Iterator[None]:
+    """
+    Applies PyCharm diff patch to add Syrupy snapshot support.
+    See: https://github.com/syrupy-project/syrupy/issues/675
+    """
+
+    try:
+        from teamcity.diff_tools import EqualsAssertionError  # type: ignore
+    except ImportError:
+        warnings.warn(
+            "Failed to patch PyCharm's diff tools. Skipping patch.",
+            stacklevel=2,
+        )
+        yield
+        return
+
+    old_init = EqualsAssertionError.__init__
+    old_init_signature = signature(old_init)
+
+    @wraps(old_init)
+    def new_init(self: "EqualsAssertionError", *args: Any, **kwargs: Any) -> None:
+
+        # Extract the __init__ arguments as originally passed in order to
+        # process them later
+        parameters = old_init_signature.bind(self, *args, **kwargs)
+        parameters.apply_defaults()
+
+        expected = parameters.arguments["expected"]
+        actual = parameters.arguments["actual"]
+        real_exception = parameters.arguments["real_exception"]
+
+        if isinstance(expected, SnapshotAssertion):
+            snapshot = expected
+        elif isinstance(actual, SnapshotAssertion):
+            snapshot = actual
+        else:
+            snapshot = None
+
+        old_init(self, *args, **kwargs)
+
+        # No snapshot was involved in the assertion. Let the old logic do its
+        # thing.
+        if snapshot is None:
+            return
+
+        # Although a snapshot was involved in the assertion, it seems the error
+        # was a result of a non-assertion exception (Ex. `assert 1/0`).
+        # Therefore, We will not do anything here either.
+        if real_exception is not None:
+            return
+
+        assertion_result = snapshot.executions[snapshot.num_executions - 1]
+        if assertion_result.exception is not None:
+            return
+
+        self.expected = str(assertion_result.recalled_data)
+        self.actual = str(assertion_result.asserted_data)
+
+    try:
+        EqualsAssertionError.__init__ = new_init
+        yield
+    finally:
+        EqualsAssertionError.__init__ = old_init

--- a/tests/integration/test_pycharm_patch.py
+++ b/tests/integration/test_pycharm_patch.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+
+import pytest
+
+
+# EqualsAssertionError comes from:
+# https://github.com/JetBrains/intellij-community/blob/cd9bfbd98a7dca730fbc469156ce1ed30364afba/python/helpers/pycharm/teamcity/diff_tools.py#L53
+@pytest.fixture
+def mock_teamcity_diff_tools(testdir: "pytest.Testdir"):
+    teamcity_pkg = testdir.mkpydir("teamcity")
+    diff_tools_file = teamcity_pkg / Path("diff_tools.py")
+    diff_tools_file.write_text(
+        """
+class EqualsAssertionError:
+    def __init__(self, expected, actual, msg=None, preformated=False, real_exception=None): # noqa: E501
+        self.real_exception = real_exception
+        self.expected = expected
+        self.actual = actual
+        self.msg = str(msg)
+    """,
+        "utf-8",
+    )
+
+
+@pytest.mark.filterwarnings("default")
+def test_logs_a_warning_if_unable_to_apply_patch(testdir):
+    testdir.makepyfile(
+        test_file="""
+    def test_case(snapshot):
+        assert snapshot == [1, 2]
+    """
+    )
+    testdir.runpytest("-v", "--snapshot-update")
+    testdir.makepyfile(
+        test_file="""
+    def test_case(snapshot):
+        assert snapshot == [1, 2, 3]
+    """
+    )
+
+    result = testdir.runpytest("-v", "--snapshot-patch-pycharm-diff")
+    result.assert_outcomes(failed=1, passed=0, warnings=1)
+
+
+@pytest.mark.filterwarnings("default")
+def test_patches_pycharm_diff_tools_when_flag_set(testdir, mock_teamcity_diff_tools):
+    # Generate initial snapshot
+    testdir.makepyfile(
+        test_file="""
+    def test_case(snapshot):
+        assert snapshot == [1, 2]
+    """
+    )
+    testdir.runpytest("-v", "--snapshot-update")
+
+    # Generate diff and mimic EqualsAssertionError being thrown
+    testdir.makepyfile(
+        test_file="""
+
+    def test_case(snapshot):
+        try:
+            assert snapshot == [1, 2, 3]
+        except:
+            from teamcity.diff_tools import EqualsAssertionError
+
+            err = EqualsAssertionError(expected=snapshot, actual=[1,2,3])
+            print("Expected:", repr(err.expected))
+            print("Actual:", repr(err.actual))
+            raise
+    """
+    )
+
+    result = testdir.runpytest("-v", "--snapshot-patch-pycharm-diff")
+    # No warnings because patch should have been successful
+    result.assert_outcomes(failed=1, passed=0, warnings=0)
+
+    result.stdout.re_match_lines(
+        [
+            r"Expected: 'list([\n  1,\n  2,\n])'",
+            # Actual is the amber-style list representation
+            r"Actual: 'list([\n  1,\n  2,\n  3,\n])'",
+        ]
+    )
+
+
+@pytest.mark.filterwarnings("default")
+def test_it_does_not_patch_pycharm_diff_tools_by_default(
+    testdir, mock_teamcity_diff_tools
+):
+    # Generate initial snapshot
+    testdir.makepyfile(
+        test_file="""
+    def test_case(snapshot):
+        assert snapshot == [1, 2]
+    """
+    )
+    testdir.runpytest("-v", "--snapshot-update")
+
+    # Generate diff and mimic EqualsAssertionError being thrown
+    testdir.makepyfile(
+        test_file="""
+
+    def test_case(snapshot):
+        try:
+            assert snapshot == [1, 2, 3]
+        except:
+            from teamcity.diff_tools import EqualsAssertionError
+
+            err = EqualsAssertionError(expected=snapshot, actual=[1,2,3])
+            print("Expected:", repr(str(err.expected)))
+            print("Actual:", repr(str(err.actual)))
+            raise
+    """
+    )
+
+    result = testdir.runpytest("-v")
+    # No warnings because patch should have been successful
+    result.assert_outcomes(failed=1, passed=0, warnings=0)
+
+    result.stdout.re_match_lines(
+        [
+            r"Expected: 'list([\n  1,\n  2,\n])'",
+            # Actual is the original list's repr. No newlines or amber-style list prefix
+            r"Actual: '[1, 2, 3]'",
+        ]
+    )

--- a/tests/integration/test_pycharm_patch.py
+++ b/tests/integration/test_pycharm_patch.py
@@ -106,7 +106,7 @@ def test_patches_pycharm_diff_tools_when_flag_set_and_snapshot_on_right(
         except:
             from teamcity.diff_tools import EqualsAssertionError
 
-            err = EqualsAssertionError(expected=snapshot, actual=[1,2,3])
+            err = EqualsAssertionError(expected=[1,2,3], actual=snapshot)
             print("Expected:", repr(err.expected))
             print("Actual:", repr(err.actual))
             raise


### PR DESCRIPTION
(Only relevant for Pycharm users) If the flag is passed, Syrupy will import and extend Pycharm's default diff script to provide more meaning full diffs when viewing snapshots mismatches in Pycharm's diff viewer

## Description

When running snapshots tests in Pycharm (in fact, when running tests in general in Pycharm), it has this cool feature where you can see the difference between the `expected` and the `actual` objects in a diff viewer:

```python
def test_example():
    expected = {
        "a": 1,
        "b": 2,
        "c": 3,
    }
    actual = {
        "a": 1,
        "b": 2,
        "c": 5,
    }
    assert actual== expected
```
After running `test_example`, and looking at Pycharm's console, we can see a link:
<img width="1371" alt="image" src="https://github.com/tophat/syrupy/assets/21122724/dffd57ec-741e-48b6-9083-0dad52c9bb77">

By clicking the `<Click to see difference>` link we can easily see the difference and know what the problem was:
<img width="1162" alt="image" src="https://github.com/tophat/syrupy/assets/21122724/3d17d188-369f-4e97-b55f-167f8db65335">

However, lets run some snapshot tests this time:
```python
@pytest.fixture
def json_snapshot(snapshot):
    return snapshot.with_defaults(extension_class=JSONSnapshotExtension)


def test_example(json_snapshot):
    actual = {
        "a": 1,
        "b": 2,
        "c": 5,
    }
    assert actual == json_snapshot
```

This time, Pycharm will show an incorrect difference that is hard to parse out:
<img width="1155" alt="image" src="https://github.com/tophat/syrupy/assets/21122724/f4fba9ee-2919-4f21-83a1-604487cefc0f">

This happens because Pycharm only sees an `actual` and an `expected` object, it doesn't have a way to know that the `actual` objects needs further parsing before the diff calculation.

This PR adds a new flag: --snapshot-patch-pycharm-diff. If the flag is active, Syrupy will attempt to import Pycharm's built-in `teamcity-messages` package (which Pycharm automatically adds to PYTHONPATH when running scripts in order to make it importable). If the import was successful, the `teamcity.diff_tools.EqualsAssertionError` object (which is responsible to calculating the string representation of the `expected` and `actual` objects in the diff view) will be patched. 

The patched object will behave the same as before. However, if either the `expected` object or the `actual` objects are instances of `syrupy.assertions.SnapshotAssertion`, the `expected` and `actual` objects will be replaced by the snapshot's recalled data and asserted data respectively.

Now, if we activate the new flag, the diff will be meaningful again:
<img width="1001" alt="image" src="https://github.com/tophat/syrupy/assets/21122724/80dc4025-2ae1-44c5-90e5-da13db006788">


## Related Issues

This PR should resolve #675 as well as the second part of #597 

## Checklist

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [X ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

As you might see in the checklist, there are a few missing parts in this PR. This is because I wasn't sure how to go about certain parts of the checklist.

1. At first I wanted to put the entire documentation in the README.md file (because that's where I saw the rest of the configuration going to. However, I wanted to put some images to have a more clear explanation and I wasn't sure where would be a good place to put them (if it is ok to put any at all).
2. I have no idea how should I go about testing this feature considering its results are accessible via Pycharm's UI.

