### PR TITLE
fix: relax python version constraint, remove upperbound

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1337,5 +1337,5 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8.1,<4"
-content-hash = "a8ba1b1ffab4e005605758d2b21cf4a0911a2dcff0f86c76b2c6e7d1b38f1e79"
+python-versions = ">=3.8.1"
+content-hash = "834cf487f5cc2d39634a863369e993f34b866da8b3b01a7fa9db3abb8d615aab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = ['src/syrupy/**/*']
 syrupy = 'syrupy'
 
 [tool.poetry.dependencies]
-python = '>=3.8.1,<4'
+python = '>=3.8.1'
 pytest = '>=7.0.0,<9.0.0'
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
closes #866 