### PR TITLE
fix: pytest-rerunfailures compatibility

### DIFF
--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -122,7 +122,10 @@ class SnapshotSession:
         self, nodeid: str, outcome: Literal["passed", "skipped", "failed"]
     ) -> None:
         if nodeid in self._selected_items:
-            self._selected_items[nodeid] = ItemStatus(outcome)
+            try:
+                self._selected_items[nodeid] = ItemStatus(outcome)
+            except ValueError:
+                pass # if we don't understand the outcome, leave the item as "not run"
 
     def finish(self) -> int:
         exitstatus = 0


### PR DESCRIPTION
Closes #879 

TODO: We likely need a test that leverages pytest-rerunfailures directly. Maybe we should introduce a set of e2e tests with a number of different plugins and merge test coverage.