### PR TITLE
fix: allow snapshot dir to be different

### DIFF
--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -37,8 +37,6 @@ def in_snapshot_dir(path: Path) -> bool:
 
 def walk_snapshot_dir(root: str) -> Iterator[str]:
     for filepath in Path(root).rglob("*"):
-        if not in_snapshot_dir(filepath):
-            continue
         if not filepath.name.startswith(".") and filepath.is_file():
             yield str(filepath)
 

--- a/tests/integration/test_snapshot_outside_directory.py
+++ b/tests/integration/test_snapshot_outside_directory.py
@@ -1,9 +1,9 @@
 import pytest
 
 
-@pytest.fixture
-def testcases(testdir, tmp_path):
-    dirname = tmp_path.joinpath("__snapshots__")
+@pytest.fixture(params=["__snapshots__", "snapshots"])
+def testcases(testdir, tmp_path, request):
+    dirname = tmp_path.joinpath(request.param)
     testdir.makeconftest(
         f"""
         import pytest

--- a/tests/syrupy/test_utils.py
+++ b/tests/syrupy/test_utils.py
@@ -42,7 +42,8 @@ def test_walk_dir_skips_non_snapshot_path(testfiles):
     _, testdir = testfiles
     snap_folder = Path("__snapshots__")
     assert {
-        str(Path(p).relative_to(Path.cwd())) for p in walk_snapshot_dir(Path(testdir.tmpdir).joinpath(snap_folder))
+        str(Path(p).relative_to(Path.cwd()))
+        for p in walk_snapshot_dir(Path(testdir.tmpdir).joinpath(snap_folder))
     } == {
         str(snap_folder.joinpath("snapfile1.ambr")),
         str(snap_folder.joinpath("snapfolder", "snapfile2.svg")),

--- a/tests/syrupy/test_utils.py
+++ b/tests/syrupy/test_utils.py
@@ -42,7 +42,7 @@ def test_walk_dir_skips_non_snapshot_path(testfiles):
     _, testdir = testfiles
     snap_folder = Path("__snapshots__")
     assert {
-        str(Path(p).relative_to(Path.cwd())) for p in walk_snapshot_dir(testdir.tmpdir)
+        str(Path(p).relative_to(Path.cwd())) for p in walk_snapshot_dir(Path(testdir.tmpdir).joinpath(snap_folder))
     } == {
         str(snap_folder.joinpath("snapfile1.ambr")),
         str(snap_folder.joinpath("snapfolder", "snapfile2.svg")),


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

This PR aims to allow setting the dirname to something else than `__snapshots__` while maintaining the functionality of a failing test suite when snapshots are unused.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #868, Where overwriting a dirname causes a test suite not to fail.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

I think I changed the `test_walk_dir_skips_non_snapshot_path` test in a wrong way, but since the function this is testing (`walk_snapshot_dir`) is always called in context, this isn't a real use case afaict
