### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/src/syrupy/extensions/amber/__init__.py
+++ b/src/syrupy/extensions/amber/__init__.py
@@ -51,7 +51,7 @@ class AmberSnapshotExtension(AbstractSyrupyExtension):
         return self.serializer_class.read_file(snapshot_location)
 
     @classmethod
-    @lru_cache()
+    @lru_cache
     def __cacheable_read_snapshot(
         cls, snapshot_location: str, cache_key: str
     ) -> "SnapshotCollection":

--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -139,7 +139,7 @@ class AmberDataSerializer:
         missing_version = True
 
         try:
-            with open(filepath, "r", encoding=TEXT_ENCODING, newline=None) as f:
+            with open(filepath, encoding=TEXT_ENCODING, newline=None) as f:
                 for line_no, line in enumerate(f):
                     if line.startswith(cls._marker_prefix):
                         marker_key, *marker_rest = line[marker_offset:].split(

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -383,9 +383,8 @@ class SnapshotReporter(ABC):
         num_lines = len(lines)
         if num_lines:
             if num_lines > self._context_line_max:
-                count_leading_whitespace: Callable[[str], int] = lambda s: len(s) - len(
-                    s.lstrip()
-                )
+                def count_leading_whitespace(s: str) -> int:
+                    return len(s) - len(s.lstrip())
                 if self._context_line_count:
                     num_space = (
                         count_leading_whitespace(lines[self._context_line_count - 1])

--- a/tasks/benchmark.py
+++ b/tasks/benchmark.py
@@ -7,4 +7,4 @@ def benchmark(ctx, report=False):
     Run and generate benchmarks for current code
     """
 
-    ctx.run(f"pytest benchmarks --benchmark-json=benchmarks.json")
+    ctx.run("pytest benchmarks --benchmark-json=benchmarks.json")

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -12,10 +12,10 @@ def install(ctx, upgrade=False):
     Install dependencies and update lock file.
     """
     if upgrade:
-        ctx_run(ctx, f"poetry update")
+        ctx_run(ctx, "poetry update")
     else:
-        ctx_run(ctx, f"poetry lock")
-        ctx_run(ctx, f"poetry install")
+        ctx_run(ctx, "poetry lock")
+        ctx_run(ctx, "poetry install")
 
 
 @task

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -1,4 +1,3 @@
-import os
 
 from invoke import task
 

--- a/tests/integration/test_custom_comparator.py
+++ b/tests/integration/test_custom_comparator.py
@@ -51,7 +51,7 @@ def generate_snapshots(testdir, testcases_initial):
 @pytest.mark.xfail(strict=False)
 def test_generated_snapshots(generate_snapshots):
     result = generate_snapshots[0]
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines(r"1 snapshot generated\.")
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -66,7 +66,7 @@ def test_approximate_match(generate_snapshots):
             """
     )
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines((r"test_file.py::test_passed_custom PASSED"))
+    result.stdout.re_match_lines(r"test_file.py::test_passed_custom PASSED")
     assert result.ret == 0
 
 
@@ -75,7 +75,7 @@ def test_failed_snapshots(generate_snapshots):
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=generate_snapshots[2]["failed"])
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines((r"1 snapshot failed\."))
+    result.stdout.re_match_lines(r"1 snapshot failed\.")
     assert result.ret == 1
 
 
@@ -84,5 +84,5 @@ def test_updated_snapshots(generate_snapshots):
     _, testdir, initial = generate_snapshots
     testdir.makepyfile(test_file=initial["failed"])
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"1 snapshot updated\."))
+    result.stdout.re_match_lines(r"1 snapshot updated\.")
     assert result.ret == 0

--- a/tests/integration/test_pytest_extension.py
+++ b/tests/integration/test_pytest_extension.py
@@ -24,7 +24,7 @@ def test_ignores_non_function_nodes(testdir):
     testdir.makeconftest(conftest)
     testdir.makepyfile(test_file=testcase)
     result = testdir.runpytest("test_file.py", "-v", "--snapshot-update")
-    result.stdout.re_match_lines((r".*test_file.py::CUSTOM.*"))
+    result.stdout.re_match_lines(r".*test_file.py::CUSTOM.*")
     assert result.ret == 0
 
 
@@ -56,7 +56,7 @@ def test_does_not_print_empty_snapshot_report(testdir):
     )
 
     result = testdir.runpytest("-v", "test_file_no.py", "--snapshot-update")
-    result.stdout.re_match_lines((r".*test_file_no.py.*"))
+    result.stdout.re_match_lines(r".*test_file_no.py.*")
     assert "snapshot report" not in result.stdout.str()
     assert "test_file_yes" not in result.stdout.str()
     assert result.ret == 0

--- a/tests/integration/test_single_file_multiple_extensions.py
+++ b/tests/integration/test_single_file_multiple_extensions.py
@@ -22,7 +22,7 @@ def test_multiple_file_extensions(testdir):
     test_file: Path = testdir.makepyfile(test_file=testcase)
 
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines(r"1 snapshot generated\.")
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -35,7 +35,7 @@ def test_multiple_file_extensions(testdir):
     assert snapshot_file.exists()
 
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines((r"1 snapshot passed\."))
+    result.stdout.re_match_lines(r"1 snapshot passed\.")
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -61,7 +61,7 @@ def test_class_style(testdir):
     test_file: Path = testdir.makepyfile(test_file=testcase)
 
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines(r"1 snapshot generated\.")
     assert "deleted" not in result.stdout.str()
     assert result.ret == 0
 
@@ -71,6 +71,6 @@ def test_class_style(testdir):
     assert snapshot_file.exists()
 
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines((r"1 snapshot passed\."))
+    result.stdout.re_match_lines(r"1 snapshot passed\.")
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0

--- a/tests/integration/test_snapshot_option_extension.py
+++ b/tests/integration/test_snapshot_option_extension.py
@@ -23,7 +23,7 @@ def test_snapshot_default_extension_option_success(testfile):
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
     )
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines(r"1 snapshot generated\.")
     assert Path(
         testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
     ).exists()

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -58,7 +58,7 @@ def test_snapshot_default_extension_option_success(testfile):
         "--snapshot-default-extension",
         "extension_file.MySingleFileExtension",
     )
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines(r"1 snapshot generated\.")
     assert Path(
         testfile.path, "__snapshots__", "test_file", "test_default.raw"
     ).exists()

--- a/tests/integration/test_snapshot_option_include_details.py
+++ b/tests/integration/test_snapshot_option_include_details.py
@@ -47,7 +47,7 @@ def run_testfiles_with_update(testdir):
             }
         )
         result = testdir.runpytest("-v", "--snapshot-update")
-        result.stdout.re_match_lines((r"[0-9]+ snapshots generated\."))
+        result.stdout.re_match_lines(r"[0-9]+ snapshots generated\.")
         return testdir
 
     return run_testfiles_with_update_impl

--- a/tests/integration/test_snapshot_option_name.py
+++ b/tests/integration/test_snapshot_option_name.py
@@ -28,7 +28,7 @@ def run_testcases(testdir, testcases):
         "-v",
         "--snapshot-update",
     )
-    result.stdout.re_match_lines((r"2 snapshots generated\."))
+    result.stdout.re_match_lines(r"2 snapshots generated\.")
     return testdir, testcases
 
 

--- a/tests/integration/test_snapshot_option_update.py
+++ b/tests/integration/test_snapshot_option_update.py
@@ -114,7 +114,7 @@ def run_testcases(testdir, testcases_initial):
     sys.path.append(str(testdir.tmpdir))
     testdir.makepyfile(**testcases_initial)
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"10 snapshots generated."))
+    result.stdout.re_match_lines(r"10 snapshots generated.")
     assert "Can not relate snapshot name" not in result.stdout.str()
 
     return result, testdir, testcases_initial
@@ -185,7 +185,7 @@ def test_update_success_shows_snapshot_report(run_testcases, testcases_updated):
     testdir = run_testcases[1]
     testdir.makepyfile(**testcases_updated)
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"5 snapshots passed\. 5 snapshots updated\."))
+    result.stdout.re_match_lines(r"5 snapshots passed\. 5 snapshots updated\.")
     assert result.ret == 0
 
 
@@ -234,7 +234,7 @@ def test_update_targets_only_selected_parametrized_tests_for_update_dash_k(
     testdir = run_testcases[1]
     testdir.makepyfile(**updated_tests)
     result = testdir.runpytest("-v", "--snapshot-update", "-k", "test_used[2]")
-    result.stdout.re_match_lines((r"1 snapshot updated\."))
+    result.stdout.re_match_lines(r"1 snapshot updated\.")
     assert "Deleted" not in result.stdout.str()
     snapshot_path = [testdir.tmpdir, "__snapshots__"]
     assert Path(*snapshot_path, "test_used.ambr").exists()
@@ -286,7 +286,7 @@ def test_update_targets_only_selected_class_tests_dash_k(testdir):
     assert Path(testdir.tmpdir, "__snapshots__", "test_content.ambr").exists()
 
     result = testdir.runpytest("test_content.py", "-v", "-k test_case_2")
-    result.stdout.re_match_lines((r"1 snapshot passed\."))
+    result.stdout.re_match_lines(r"1 snapshot passed\.")
     assert "snaphot unused" not in result.stdout.str()
 
 
@@ -306,7 +306,7 @@ def test_update_targets_only_selected_module_tests_dash_k(testdir):
     assert Path(testdir.tmpdir, "__snapshots__", "test_content.ambr").exists()
 
     result = testdir.runpytest("test_content.py", "-v", "-k test_case_2")
-    result.stdout.re_match_lines((r"1 snapshot passed\."))
+    result.stdout.re_match_lines(r"1 snapshot passed\.")
     assert "snaphot unused" not in result.stdout.str()
 
 
@@ -316,7 +316,7 @@ def test_update_targets_only_selected_module_tests_nodes(run_testcases):
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
     testfile = Path(testdir.tmpdir, "test_used.py")
     result = testdir.runpytest("-v", f"{testfile}::test_used", "--snapshot-update")
-    result.stdout.re_match_lines((r"3 snapshots passed\."))
+    result.stdout.re_match_lines(r"3 snapshots passed\.")
     assert "unused" not in result.stdout.str()
     assert "updated" not in result.stdout.str()
     assert "deleted" not in result.stdout.str()
@@ -334,7 +334,7 @@ def test_update_targets_only_selected_module_tests_nodes_pyargs(run_testcases):
         "--pyargs",
         "test_used::test_used",
     )
-    result.stdout.re_match_lines((r"3 snapshots passed\."))
+    result.stdout.re_match_lines(r"3 snapshots passed\.")
     assert "unused" not in result.stdout.str()
     assert "updated" not in result.stdout.str()
     assert "deleted" not in result.stdout.str()

--- a/tests/integration/test_snapshot_option_warn_unused.py
+++ b/tests/integration/test_snapshot_option_warn_unused.py
@@ -24,7 +24,7 @@ def run_testcases(testdir, testcases):
     pyfile_content = "\n\n".join(testcases.values())
     testdir.makepyfile(test_file=pyfile_content)
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"2 snapshots generated\."))
+    result.stdout.re_match_lines(r"2 snapshots generated\.")
     return testdir, testcases
 
 

--- a/tests/integration/test_snapshot_outside_directory.py
+++ b/tests/integration/test_snapshot_outside_directory.py
@@ -52,7 +52,7 @@ def generate_snapshots(testdir, testcases):
 
 def test_generated_snapshots(generate_snapshots):
     result = generate_snapshots[0]
-    result.stdout.re_match_lines((r"2 snapshots generated\."))
+    result.stdout.re_match_lines(r"2 snapshots generated\.")
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -61,7 +61,7 @@ def test_unmatched_snapshots(generate_snapshots):
     _, testdir, testcases = generate_snapshots
     testdir.makepyfile(test_file=testcases["one"])
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines((r"1 snapshot passed. 1 snapshot unused\."))
+    result.stdout.re_match_lines(r"1 snapshot passed. 1 snapshot unused\.")
     assert result.ret == 1
 
 

--- a/tests/integration/test_snapshot_similar_names_default.py
+++ b/tests/integration/test_snapshot_similar_names_default.py
@@ -32,7 +32,7 @@ def run_testcases(testdir, testcases):
         test_1=pyfile_content, test_2=pyfile_content, test_1_with_suffix=pyfile_content
     )
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"9 snapshots generated\."))
+    result.stdout.re_match_lines(r"9 snapshots generated\.")
     return testdir, testcases
 
 

--- a/tests/integration/test_snapshot_similar_names_file_extension.py
+++ b/tests/integration/test_snapshot_similar_names_file_extension.py
@@ -37,7 +37,7 @@ def run_testcases(testdir, testcases):
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
     )
-    result.stdout.re_match_lines((r"9 snapshots generated\."))
+    result.stdout.re_match_lines(r"9 snapshots generated\.")
     return testdir, testcases
 
 

--- a/tests/integration/test_snapshot_use_extension.py
+++ b/tests/integration/test_snapshot_use_extension.py
@@ -106,13 +106,13 @@ def test_unsaved_snapshots(testdir, testcases_initial):
 def test_failed_snapshots(testdir, testcases_initial):
     testdir.makepyfile(test_file=testcases_initial["failed"])
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"2 snapshots failed\."))
+    result.stdout.re_match_lines(r"2 snapshots failed\.")
     assert result.ret == 1
 
 
 def test_generated_snapshots(generate_snapshots):
     result = generate_snapshots[0]
-    result.stdout.re_match_lines((r"4 snapshots generated\."))
+    result.stdout.re_match_lines(r"4 snapshots generated\.")
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -121,7 +121,7 @@ def test_unmatched_snapshots(generate_snapshots, testcases_updated):
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=testcases_updated["passed"])
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines((r"1 snapshot failed\. 2 snapshots unused\."))
+    result.stdout.re_match_lines(r"1 snapshot failed\. 2 snapshots unused\.")
     assert result.ret == 1
 
 
@@ -129,7 +129,7 @@ def test_updated_snapshots(generate_snapshots, testcases_updated):
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=testcases_updated["passed"])
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"1 snapshot updated\. 2 unused snapshots deleted\."))
+    result.stdout.re_match_lines(r"1 snapshot updated\. 2 unused snapshots deleted\.")
     assert result.ret == 0
 
 

--- a/tests/integration/test_xfail.py
+++ b/tests/integration/test_xfail.py
@@ -11,7 +11,7 @@ def test_no_failure_printed_if_all_failures_xfailed(testdir):
         )
     )
     result = testdir.runpytest("-v")
-    result.stdout.no_re_match_line((r".*snapshot failed*"))
+    result.stdout.no_re_match_line(r".*snapshot failed*")
     assert result.ret == 0
 
 
@@ -31,8 +31,8 @@ def test_failures_printed_if_only_some_failures_xfailed(testdir):
         )
     )
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines((r".*1 snapshot failed*"))
-    result.stdout.re_match_lines((r".*1 snapshot xfailed*"))
+    result.stdout.re_match_lines(r".*1 snapshot failed*")
+    result.stdout.re_match_lines(r".*1 snapshot xfailed*")
     assert result.ret == 1
 
 
@@ -49,6 +49,6 @@ def test_failure_printed_if_xfail_does_not_run(testdir):
         )
     )
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines((r".*1 snapshot failed*"))
-    result.stdout.no_re_match_line((r".*1 snapshot xfailed*"))
+    result.stdout.re_match_lines(r".*1 snapshot failed*")
+    result.stdout.no_re_match_line(r".*1 snapshot xfailed*")
     assert result.ret == 1


### PR DESCRIPTION
## Description

Filter all code over `pyupgracde --py38-plus`.

## Related Issues
N/A

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [ ] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
