### PR TITLE
chore: use tuple in stdout.re_match_lines

### DIFF
--- a/tests/integration/test_custom_comparator.py
+++ b/tests/integration/test_custom_comparator.py
@@ -51,7 +51,7 @@ def generate_snapshots(testdir, testcases_initial):
 @pytest.mark.xfail(strict=False)
 def test_generated_snapshots(generate_snapshots):
     result = generate_snapshots[0]
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines((r"1 snapshot generated\.",))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -66,7 +66,7 @@ def test_approximate_match(generate_snapshots, plugin_args_fails_xdist):
             """
     )
     result = testdir.runpytest("-v", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"test_file.py::test_passed_custom PASSED"))
+    result.stdout.re_match_lines((r"test_file.py::test_passed_custom PASSED",))
     assert result.ret == 0
 
 
@@ -75,7 +75,7 @@ def test_failed_snapshots(generate_snapshots):
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=generate_snapshots[2]["failed"])
     result = testdir.runpytest("-v")
-    result.stdout.re_match_lines((r"1 snapshot failed\."))
+    result.stdout.re_match_lines((r"1 snapshot failed\.",))
     assert result.ret == 1
 
 
@@ -84,5 +84,5 @@ def test_updated_snapshots(generate_snapshots, plugin_args_fails_xdist):
     _, testdir, initial = generate_snapshots
     testdir.makepyfile(test_file=initial["failed"])
     result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"1 snapshot updated\."))
+    result.stdout.re_match_lines((r"1 snapshot updated\.",))
     assert result.ret == 0

--- a/tests/integration/test_pycharm_patch.py
+++ b/tests/integration/test_pycharm_patch.py
@@ -77,11 +77,11 @@ def test_patches_pycharm_diff_tools_when_flag_set(
     result.assert_outcomes(failed=1, passed=0, warnings=0)
 
     result.stdout.re_match_lines(
-        [
+        (
             r"Expected: 'list([\n  1,\n  2,\n])'",
             # Actual is the amber-style list representation
             r"Actual: 'list([\n  1,\n  2,\n  3,\n])'",
-        ]
+        )
     )
 
 
@@ -120,11 +120,11 @@ def test_patches_pycharm_diff_tools_when_flag_set_and_snapshot_on_right(
     result.assert_outcomes(failed=1, passed=0, warnings=0)
 
     result.stdout.re_match_lines(
-        [
+        (
             r"Expected: 'list([\n  1,\n  2,\n])'",
             # Actual is the amber-style list representation
             r"Actual: 'list([\n  1,\n  2,\n  3,\n])'",
-        ]
+        )
     )
 
 
@@ -163,11 +163,11 @@ def test_it_does_not_patch_pycharm_diff_tools_by_default(
     result.assert_outcomes(failed=1, passed=0, warnings=0)
 
     result.stdout.re_match_lines(
-        [
+        (
             r"Expected: 'list([\n  1,\n  2,\n])'",
             # Actual is the original list's repr. No newlines or amber-style list prefix
             r"Actual: '[1, 2, 3]'",
-        ]
+        )
     )
 
 
@@ -197,10 +197,10 @@ def test_it_has_no_impact_on_non_syrupy_assertions(
     result.assert_outcomes(failed=1, passed=0, warnings=0)
 
     result.stdout.re_match_lines(
-        [
+        (
             r"Expected: '[1, 3]'",
             r"Actual: '[1, 2, 3]'",
-        ]
+        )
     )
 
 
@@ -234,8 +234,8 @@ def test_has_no_impact_on_real_exceptions_that_are_not_assertion_errors(
     result.assert_outcomes(failed=1, passed=0, warnings=0)
 
     result.stdout.re_match_lines(
-        [
+        (
             r"Expected: '[1, 3]'",
             r"Actual: '[1, 2, 3]'",
-        ]
+        )
     )

--- a/tests/integration/test_pytest_extension.py
+++ b/tests/integration/test_pytest_extension.py
@@ -24,7 +24,7 @@ def test_ignores_non_function_nodes(testdir, plugin_args):
     testdir.makeconftest(conftest)
     testdir.makepyfile(test_file=testcase)
     result = testdir.runpytest("test_file.py", "-v", "--snapshot-update", *plugin_args)
-    result.stdout.re_match_lines((r".*test_file.py::CUSTOM.*"))
+    result.stdout.re_match_lines((r".*test_file.py::CUSTOM.*",))
     assert result.ret == 0
 
 
@@ -63,7 +63,7 @@ def test_does_not_print_empty_snapshot_report(testdir, plugin_args_fails_xdist):
     result = testdir.runpytest(
         "-v", "test_file_no.py", "--snapshot-update", *plugin_args_fails_xdist
     )
-    result.stdout.re_match_lines((r".*test_file_no.py.*"))
+    result.stdout.re_match_lines((r".*test_file_no.py.*",))
     assert "snapshot report" not in result.stdout.str()
     assert "test_file_yes" not in result.stdout.str()
     assert result.ret == 0

--- a/tests/integration/test_single_file_multiple_extensions.py
+++ b/tests/integration/test_single_file_multiple_extensions.py
@@ -22,7 +22,7 @@ def test_multiple_file_extensions(testdir, plugin_args_fails_xdist):
     test_file: Path = testdir.makepyfile(test_file=testcase)
 
     result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines((r"1 snapshot generated\.",))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -35,7 +35,7 @@ def test_multiple_file_extensions(testdir, plugin_args_fails_xdist):
     assert snapshot_file.exists()
 
     result = testdir.runpytest("-v", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"1 snapshot passed\."))
+    result.stdout.re_match_lines((r"1 snapshot passed\.",))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -61,7 +61,7 @@ def test_class_style(testdir, plugin_args_fails_xdist):
     test_file: Path = testdir.makepyfile(test_file=testcase)
 
     result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines((r"1 snapshot generated\.",))
     assert "deleted" not in result.stdout.str()
     assert result.ret == 0
 
@@ -71,6 +71,6 @@ def test_class_style(testdir, plugin_args_fails_xdist):
     assert snapshot_file.exists()
 
     result = testdir.runpytest("-v", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"1 snapshot passed\."))
+    result.stdout.re_match_lines((r"1 snapshot passed\.",))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0

--- a/tests/integration/test_snapshot_option_extension.py
+++ b/tests/integration/test_snapshot_option_extension.py
@@ -23,7 +23,7 @@ def test_snapshot_default_extension_option_success(testfile):
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
     )
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines((r"1 snapshot generated\.",))
     assert Path(
         testfile.tmpdir, "__snapshots__", "test_file", "test_default.raw"
     ).exists()

--- a/tests/integration/test_snapshot_option_extension_pythonpath.py
+++ b/tests/integration/test_snapshot_option_extension_pythonpath.py
@@ -58,7 +58,7 @@ def test_snapshot_default_extension_option_success(testfile):
         "--snapshot-default-extension",
         "extension_file.MySingleFileExtension",
     )
-    result.stdout.re_match_lines((r"1 snapshot generated\."))
+    result.stdout.re_match_lines((r"1 snapshot generated\.",))
     assert Path(
         testfile.path, "__snapshots__", "test_file", "test_default.raw"
     ).exists()

--- a/tests/integration/test_snapshot_option_include_details.py
+++ b/tests/integration/test_snapshot_option_include_details.py
@@ -47,7 +47,7 @@ def run_testfiles_with_update(testdir):
             }
         )
         result = testdir.runpytest("-v", "--snapshot-update")
-        result.stdout.re_match_lines((r"[0-9]+ snapshots generated\."))
+        result.stdout.re_match_lines((r"[0-9]+ snapshots generated\.",))
         return testdir
 
     return run_testfiles_with_update_impl

--- a/tests/integration/test_snapshot_option_name.py
+++ b/tests/integration/test_snapshot_option_name.py
@@ -28,14 +28,14 @@ def run_testcases(testdir, testcases):
         "-v",
         "--snapshot-update",
     )
-    result.stdout.re_match_lines((r"2 snapshots generated\."))
+    result.stdout.re_match_lines((r"2 snapshots generated\.",))
     return testdir, testcases
 
 
 def test_run_all(run_testcases, plugin_args_fails_xdist):
     testdir, testcases = run_testcases
     result = testdir.runpytest("-v", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines("2 snapshots passed")
+    result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0
 
 
@@ -43,7 +43,7 @@ def test_failure(run_testcases, plugin_args_fails_xdist):
     testdir, testcases = run_testcases
     testdir.makepyfile(test_1=testcases["modified"])
     result = testdir.runpytest("-vv", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines("1 snapshot failed. 1 snapshot passed.")
+    result.stdout.re_match_lines(("1 snapshot failed. 1 snapshot passed.",))
     assert result.ret == 1
 
 
@@ -52,5 +52,5 @@ def test_update(run_testcases, plugin_args_fails_xdist):
     testdir.makepyfile(test_1=testcases["modified"])
     result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
     assert "Can not relate snapshot name" not in str(result.stdout)
-    result.stdout.re_match_lines("1 snapshot passed. 1 snapshot updated.")
+    result.stdout.re_match_lines(("1 snapshot passed. 1 snapshot updated.",))
     assert result.ret == 0

--- a/tests/integration/test_snapshot_option_update.py
+++ b/tests/integration/test_snapshot_option_update.py
@@ -114,7 +114,7 @@ def run_testcases(testdir, testcases_initial):
     sys.path.append(str(testdir.tmpdir))
     testdir.makepyfile(**testcases_initial)
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"10 snapshots generated."))
+    result.stdout.re_match_lines((r"10 snapshots generated.",))
     assert "Can not relate snapshot name" not in result.stdout.str()
 
     return result, testdir, testcases_initial
@@ -189,7 +189,7 @@ def test_update_success_shows_snapshot_report(
     testdir = run_testcases[1]
     testdir.makepyfile(**testcases_updated)
     result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"5 snapshots passed\. 5 snapshots updated\."))
+    result.stdout.re_match_lines((r"5 snapshots passed\. 5 snapshots updated\.",))
     assert result.ret == 0
 
 
@@ -242,7 +242,7 @@ def test_update_targets_only_selected_parametrized_tests_for_update_dash_k(
     result = testdir.runpytest(
         "-v", "--snapshot-update", *plugin_args_fails_xdist, "-k", "test_used[2]"
     )
-    result.stdout.re_match_lines((r"1 snapshot updated\."))
+    result.stdout.re_match_lines((r"1 snapshot updated\.",))
     assert "Deleted" not in result.stdout.str()
     snapshot_path = [testdir.tmpdir, "__snapshots__"]
     assert Path(*snapshot_path, "test_used.ambr").exists()
@@ -300,7 +300,7 @@ def test_update_targets_only_selected_class_tests_dash_k(
     result = testdir.runpytest(
         "test_content.py", "-v", *plugin_args_fails_xdist, "-k", "test_case_2"
     )
-    result.stdout.re_match_lines((r"1 snapshot passed\."))
+    result.stdout.re_match_lines((r"1 snapshot passed\.",))
     assert "snaphot unused" not in result.stdout.str()
 
 
@@ -324,7 +324,7 @@ def test_update_targets_only_selected_module_tests_dash_k(
     result = testdir.runpytest(
         "test_content.py", "-v", *plugin_args_fails_xdist, "-k", "test_case_2"
     )
-    result.stdout.re_match_lines((r"1 snapshot passed\."))
+    result.stdout.re_match_lines((r"1 snapshot passed\.",))
     assert "snaphot unused" not in result.stdout.str()
 
 
@@ -338,7 +338,7 @@ def test_update_targets_only_selected_module_tests_nodes(
     result = testdir.runpytest(
         "-v", f"{testfile}::test_used", "--snapshot-update", *plugin_args_fails_xdist
     )
-    result.stdout.re_match_lines((r"3 snapshots passed\."))
+    result.stdout.re_match_lines((r"3 snapshots passed\.",))
     assert "unused" not in result.stdout.str()
     assert "updated" not in result.stdout.str()
     assert "deleted" not in result.stdout.str()
@@ -359,7 +359,7 @@ def test_update_targets_only_selected_module_tests_nodes_pyargs(
         "--pyargs",
         "test_used::test_used",
     )
-    result.stdout.re_match_lines((r"3 snapshots passed\."))
+    result.stdout.re_match_lines((r"3 snapshots passed\.",))
     assert "unused" not in result.stdout.str()
     assert "updated" not in result.stdout.str()
     assert "deleted" not in result.stdout.str()

--- a/tests/integration/test_snapshot_option_warn_unused.py
+++ b/tests/integration/test_snapshot_option_warn_unused.py
@@ -24,7 +24,7 @@ def run_testcases(testdir, testcases):
     pyfile_content = "\n\n".join(testcases.values())
     testdir.makepyfile(test_file=pyfile_content)
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"2 snapshots generated\."))
+    result.stdout.re_match_lines((r"2 snapshots generated\.",))
     return testdir, testcases
 
 

--- a/tests/integration/test_snapshot_outside_directory.py
+++ b/tests/integration/test_snapshot_outside_directory.py
@@ -52,7 +52,7 @@ def generate_snapshots(testdir, testcases):
 
 def test_generated_snapshots(generate_snapshots):
     result = generate_snapshots[0]
-    result.stdout.re_match_lines((r"2 snapshots generated\."))
+    result.stdout.re_match_lines((r"2 snapshots generated\.",))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -61,7 +61,7 @@ def test_unmatched_snapshots(generate_snapshots, plugin_args_fails_xdist):
     _, testdir, testcases = generate_snapshots
     testdir.makepyfile(test_file=testcases["one"])
     result = testdir.runpytest("-v", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"1 snapshot passed. 1 snapshot unused\."))
+    result.stdout.re_match_lines((r"1 snapshot passed. 1 snapshot unused\.",))
     assert result.ret == 1
 
 

--- a/tests/integration/test_snapshot_similar_names_default.py
+++ b/tests/integration/test_snapshot_similar_names_default.py
@@ -32,28 +32,28 @@ def run_testcases(testdir, testcases):
         test_1=pyfile_content, test_2=pyfile_content, test_1_with_suffix=pyfile_content
     )
     result = testdir.runpytest("-v", "--snapshot-update")
-    result.stdout.re_match_lines((r"9 snapshots generated\."))
+    result.stdout.re_match_lines((r"9 snapshots generated\.",))
     return testdir, testcases
 
 
 def test_run_all(run_testcases, plugin_args_fails_xdist):
     testdir, testcases = run_testcases
     result = testdir.runpytest("-v", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines("9 snapshots passed")
+    result.stdout.re_match_lines(("9 snapshots passed",))
     assert result.ret == 0
 
 
 def test_run_single_file(run_testcases, plugin_args_fails_xdist):
     testdir, testcases = run_testcases
     result = testdir.runpytest("-v", "test_1.py", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines("3 snapshots passed")
+    result.stdout.re_match_lines(("3 snapshots passed",))
     assert result.ret == 0
 
 
 def test_run_single_test_case_in_file(run_testcases, plugin_args_fails_xdist):
     testdir, testcases = run_testcases
     result = testdir.runpytest("-v", "test_2.py::test_a", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines("1 snapshot passed")
+    result.stdout.re_match_lines(("1 snapshot passed",))
     assert result.ret == 0
 
 
@@ -66,7 +66,7 @@ def test_run_all_but_one(run_testcases, plugin_args_fails_xdist):
         "test_2.py::test_a",
         *plugin_args_fails_xdist,
     )
-    result.stdout.re_match_lines("4 snapshots passed")
+    result.stdout.re_match_lines(("4 snapshots passed",))
     assert result.ret == 0
 
 
@@ -79,7 +79,7 @@ def test_run_both_files_by_node(run_testcases, plugin_args_fails_xdist):
         "test_2.py::test_a",
         *plugin_args_fails_xdist,
     )
-    result.stdout.re_match_lines("2 snapshots passed")
+    result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0
 
 
@@ -92,5 +92,5 @@ def test_run_both_files_by_node_2(run_testcases, plugin_args_fails_xdist):
         "test_2.py::test_a",
         *plugin_args_fails_xdist,
     )
-    result.stdout.re_match_lines("2 snapshots passed")
+    result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0

--- a/tests/integration/test_snapshot_similar_names_file_extension.py
+++ b/tests/integration/test_snapshot_similar_names_file_extension.py
@@ -37,7 +37,7 @@ def run_testcases(testdir, testcases):
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
     )
-    result.stdout.re_match_lines((r"9 snapshots generated\."))
+    result.stdout.re_match_lines((r"9 snapshots generated\.",))
     return testdir, testcases
 
 
@@ -49,7 +49,7 @@ def test_run_all(run_testcases, plugin_args_fails_xdist):
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
         *plugin_args_fails_xdist,
     )
-    result.stdout.re_match_lines("9 snapshots passed")
+    result.stdout.re_match_lines(("9 snapshots passed",))
     assert result.ret == 0
 
 
@@ -62,7 +62,7 @@ def test_run_single_file(run_testcases, plugin_args_fails_xdist):
         "test_1.py",
         *plugin_args_fails_xdist,
     )
-    result.stdout.re_match_lines("3 snapshots passed")
+    result.stdout.re_match_lines(("3 snapshots passed",))
     assert result.ret == 0
 
 
@@ -75,7 +75,7 @@ def test_run_single_test_case_in_file(run_testcases, plugin_args_fails_xdist):
         "test_2.py::test_a",
         *plugin_args_fails_xdist,
     )
-    result.stdout.re_match_lines("1 snapshot passed")
+    result.stdout.re_match_lines(("1 snapshot passed",))
     assert result.ret == 0
 
 
@@ -90,7 +90,7 @@ def test_run_all_but_one(run_testcases, plugin_args_fails_xdist):
         "test_2.py::test_a",
         *plugin_args_fails_xdist,
     )
-    result.stdout.re_match_lines("4 snapshots passed")
+    result.stdout.re_match_lines(("4 snapshots passed",))
     assert result.ret == 0
 
 
@@ -105,7 +105,7 @@ def test_run_both_files_by_node(run_testcases, plugin_args_fails_xdist):
         "test_2.py::test_a",
         *plugin_args_fails_xdist,
     )
-    result.stdout.re_match_lines("2 snapshots passed")
+    result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0
 
 
@@ -120,5 +120,5 @@ def test_run_both_files_by_node_2(run_testcases, plugin_args_fails_xdist):
         "test_2.py::test_a",
         *plugin_args_fails_xdist,
     )
-    result.stdout.re_match_lines("2 snapshots passed")
+    result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0

--- a/tests/integration/test_snapshot_use_extension.py
+++ b/tests/integration/test_snapshot_use_extension.py
@@ -107,13 +107,13 @@ def test_unsaved_snapshots(testdir, testcases_initial):
 def test_failed_snapshots(testdir, testcases_initial, plugin_args_fails_xdist):
     testdir.makepyfile(test_file=testcases_initial["failed"])
     result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"2 snapshots failed\."))
+    result.stdout.re_match_lines((r"2 snapshots failed\.",))
     assert result.ret == 1
 
 
 def test_generated_snapshots(generate_snapshots):
     result = generate_snapshots[0]
-    result.stdout.re_match_lines((r"4 snapshots generated\."))
+    result.stdout.re_match_lines((r"4 snapshots generated\.",))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
@@ -124,7 +124,7 @@ def test_unmatched_snapshots(
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=testcases_updated["passed"])
     result = testdir.runpytest("-v", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"1 snapshot failed\. 2 snapshots unused\."))
+    result.stdout.re_match_lines((r"1 snapshot failed\. 2 snapshots unused\.",))
     assert result.ret == 1
 
 
@@ -134,7 +134,9 @@ def test_updated_snapshots(
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=testcases_updated["passed"])
     result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r"1 snapshot updated\. 2 unused snapshots deleted\."))
+    result.stdout.re_match_lines(
+        (r"1 snapshot updated\. 2 unused snapshots deleted\.",)
+    )
     assert result.ret == 0
 
 

--- a/tests/integration/test_xfail.py
+++ b/tests/integration/test_xfail.py
@@ -11,7 +11,7 @@ def test_no_failure_printed_if_all_failures_xfailed(testdir, plugin_args):
         )
     )
     result = testdir.runpytest("-v", *plugin_args)
-    result.stdout.no_re_match_line((r".*snapshot failed*"))
+    result.stdout.no_re_match_line(r".*snapshot failed*")
     assert result.ret == 0
 
 
@@ -33,8 +33,8 @@ def test_failures_printed_if_only_some_failures_xfailed(
         )
     )
     result = testdir.runpytest("-v", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r".*1 snapshot failed*"))
-    result.stdout.re_match_lines((r".*1 snapshot xfailed*"))
+    result.stdout.re_match_lines((r".*1 snapshot failed*",))
+    result.stdout.re_match_lines((r".*1 snapshot xfailed*",))
     assert result.ret == 1
 
 
@@ -51,6 +51,6 @@ def test_failure_printed_if_xfail_does_not_run(testdir, plugin_args_fails_xdist)
         )
     )
     result = testdir.runpytest("-v", *plugin_args_fails_xdist)
-    result.stdout.re_match_lines((r".*1 snapshot failed*"))
-    result.stdout.no_re_match_line((r".*1 snapshot xfailed*"))
+    result.stdout.re_match_lines((r".*1 snapshot failed*",))
+    result.stdout.no_re_match_line(r".*1 snapshot xfailed*")
     assert result.ret == 1


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

This was spotted when trying to enforce pyupgrade rules in ruff, and rule UP034 was causing issues: https://docs.astral.sh/ruff/rules/extraneous-parentheses/

Sometimes the first argument was a tuple `stdout.re_match_lines(("a","b"))`, sometimes it was a raw string `stdout.re_match_lines("a")`, and other times it was a bracketed raw string `stdout.re_match_lines(("a"))`

Instead of simply converting the bracketed raw string into non-bracketed raw strings, I think it makes better sense to convert all the raw strings to tuples, as `result.stdout.re_match_lines` is supposed to have a `Sequence[str]` as first argument:
```python
    def re_match_lines(
        self, lines2: Sequence[str], *, consecutive: bool = False
    ) -> None:
```


## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

This is not picked up by `mypy` as strings are also a sequence of single-character strings.
Also, raw strings work behind the scene as they go through `_getlines` which converts them to a sequence.

```python
    def _getlines(self, lines2: str | Sequence[str] | Source) -> Sequence[str]:
        if isinstance(lines2, str):
            lines2 = Source(lines2)
        if isinstance(lines2, Source):
            lines2 = lines2.strip().lines
        return lines2

```
