### PR TITLE
feat: add option to disable diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ These are the cli options exposed to `pytest` by the plugin.
 | `--snapshot-default-extension` | Use to change the default snapshot extension class.                                                                            | [AmberSnapshotExtension](https://github.com/syrupy-project/syrupy/blob/main/src/syrupy/extensions/amber/__init__.py) |
 | `--snapshot-no-colors`         | Disable test results output highlighting. Equivalent to setting the environment variables `ANSI_COLORS_DISABLED` or `NO_COLOR` | Disabled by default if not in terminal.                                                                      |
 | `--snapshot-patch-pycharm-diff`| Override PyCharm's default diffs viewer when looking at snapshot diffs. See [IDE Integrations](#ide-integrations)        | `False`                                                                                                      |
+| `--snapshot-diff-mode` | Configures how diffs are displayed on assertion failure. If working with very large snapshots, disabling the diff can improve performance. | `detailed` |
 
 ### Assertion Options
 

--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -4,6 +4,7 @@ from dataclasses import (
     dataclass,
     field,
 )
+from enum import Enum
 from gettext import gettext
 from typing import (
     TYPE_CHECKING,
@@ -33,6 +34,14 @@ if TYPE_CHECKING:
         SerializedData,
         SnapshotIndex,
     )
+
+
+class DiffMode(Enum):
+    DETAILED = "detailed"
+    DISABLED = "disabled"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 @dataclass
@@ -210,7 +219,9 @@ class SnapshotAssertion:
             data, exclude=self._exclude, include=self._include, matcher=self.__matcher
         )
 
-    def get_assert_diff(self) -> List[str]:
+    def get_assert_diff(
+        self, *, diff_mode: "DiffMode" = DiffMode.DETAILED
+    ) -> List[str]:
         assertion_result = self._execution_results[self.num_executions - 1]
         if assertion_result.exception:
             if isinstance(assertion_result.exception, (TaintedSnapshotError,)):
@@ -247,7 +258,8 @@ class SnapshotAssertion:
             )
         if not assertion_result.success:
             snapshot_data = snapshot_data if snapshot_data is not None else ""
-            diff.extend(self.extension.diff_lines(serialized_data, snapshot_data))
+            if diff_mode == DiffMode.DETAILED:
+                diff.extend(self.extension.diff_lines(serialized_data, snapshot_data))
         return diff
 
     def __with_prop(self, prop_name: str, prop_value: Any) -> None:

--- a/tests/integration/test_snapshot_option_diff_mode.py
+++ b/tests/integration/test_snapshot_option_diff_mode.py
@@ -1,0 +1,49 @@
+import pytest
+
+
+@pytest.fixture
+def testfile(testdir) -> pytest.Testdir:
+    testdir.makepyfile(
+        test_file=(
+            """
+            def test_case(snapshot):
+                assert snapshot == "some-value"
+            """
+        ),
+    )
+    return testdir
+
+
+def test_diff_mode_disabled_does_not_print_diff(
+    testfile,
+):
+    # Generate initial snapshot
+    result = testfile.runpytest("-v", "--snapshot-update")
+    result.stdout.re_match_lines((r"1 snapshot generated\.",))
+    assert result.ret == 0
+
+    # Modify snapshot to generate diff
+    testfile.makepyfile(
+        test_file=(
+            """
+            def test_case(snapshot):
+                assert snapshot == "some-other-value"
+            """
+        ),
+    )
+
+    # With diff we expect to see "some-other-value"
+    result = testfile.runpytest("-v", "--snapshot-diff-mode=detailed")
+    result.stdout.re_match_lines(
+        (
+            r".*- 'some-value'",
+            r".*\+ 'some-other-value'",
+        )
+    )
+    assert result.ret == 1
+
+    # Without diff we do not expect to see "some-other-value"
+    result = testfile.runpytest("-v", "--snapshot-diff-mode=disabled")
+    result.stdout.no_re_match_line(r".*- 'some-value'")
+    result.stdout.no_re_match_line(r".*\+ 'some-other-value'")
+    assert result.ret == 1

--- a/tests/syrupy/__snapshots__/test_diff_mode.ambr
+++ b/tests/syrupy/__snapshots__/test_diff_mode.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_can_be_stringified
+  'detailed'
+# ---
+# name: test_can_be_stringified.1
+  'disabled'
+# ---

--- a/tests/syrupy/test_diff_mode.py
+++ b/tests/syrupy/test_diff_mode.py
@@ -1,0 +1,6 @@
+from syrupy.assertion import DiffMode
+
+
+def test_can_be_stringified(snapshot):
+    assert snapshot == str(DiffMode.DETAILED)
+    assert snapshot == str(DiffMode.DISABLED)


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

For extremely large snapshot files, the diff algorithm is not very efficient. Until the algorithm can be modified to work with large files, there is now a --snapshot-diff-mode=disabled flag that can be specified to disable diffing on snapshot assertion failures.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #581

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
