### PR TITLE
fix: check current session's pending-write queue when recalling snapshots (e.g. diffing)

### DIFF
--- a/src/syrupy/assertion.py
+++ b/src/syrupy/assertion.py
@@ -377,11 +377,7 @@ class SnapshotAssertion:
     ) -> Tuple[Optional["SerializableData"], bool]:
         try:
             return (
-                self.extension.read_snapshot(
-                    test_location=self.test_location,
-                    index=index,
-                    session_id=str(id(self.session)),
-                ),
+                self.session.recall_snapshot(self.extension, self.test_location, index),
                 False,
             )
         except SnapshotDoesNotExist:

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -13,7 +13,7 @@ import pytest
 from syrupy.constants import PYTEST_NODE_SEP
 
 
-@dataclass
+@dataclass(frozen=True)
 class PyTestLocation:
     item: "pytest.Item"
     nodename: Optional[str] = field(init=False)
@@ -23,27 +23,41 @@ class PyTestLocation:
     filepath: str = field(init=False)
 
     def __post_init__(self) -> None:
+        # NB. we're in a frozen dataclass, but need to transform the values that the caller
+        # supplied... we do so by (ab)using object.__setattr__ to forcibly set the attributes. (See
+        # rejected PEP-0712 for an example of a better way to handle this.)
+        #
+        # This is safe because this all happens during initialization: `self` hasn't been hashed
+        # (or, e.g., stored in a dict), so the mutation won't be noticed.
         if self.is_doctest:
             return self.__attrs_post_init_doc__()
         self.__attrs_post_init_def__()
 
     def __attrs_post_init_def__(self) -> None:
         node_path: Path = getattr(self.item, "path")  # noqa: B009
-        self.filepath = str(node_path.absolute())
+        # See __post_init__ for discussion of object.__setattr__
+        object.__setattr__(self, "filepath", str(node_path.absolute()))
         obj = getattr(self.item, "obj")  # noqa: B009
-        self.modulename = obj.__module__
-        self.methodname = obj.__name__
-        self.nodename = getattr(self.item, "name", None)
-        self.testname = self.nodename or self.methodname
+        object.__setattr__(self, "modulename", obj.__module__)
+        object.__setattr__(self, "methodname", obj.__name__)
+        object.__setattr__(self, "nodename", getattr(self.item, "name", None))
+        object.__setattr__(self, "testname", self.nodename or self.methodname)
 
     def __attrs_post_init_doc__(self) -> None:
         doctest = getattr(self.item, "dtest")  # noqa: B009
-        self.filepath = doctest.filename
+        # See __post_init__ for discussion of object.__setattr__
+        object.__setattr__(self, "filepath", doctest.filename)
         test_relfile, test_node = self.nodeid.split(PYTEST_NODE_SEP)
         test_relpath = Path(test_relfile)
-        self.modulename = ".".join([*test_relpath.parent.parts, test_relpath.stem])
-        self.nodename = test_node.replace(f"{self.modulename}.", "")
-        self.testname = self.nodename or self.methodname
+        object.__setattr__(
+            self,
+            "modulename",
+            ".".join([*test_relpath.parent.parts, test_relpath.stem]),
+        )
+        object.__setattr__(
+            self, "nodename", test_node.replace(f"{self.modulename}.", "")
+        )
+        object.__setattr__(self, "testname", self.nodename or self.methodname)
 
     @property
     def classname(self) -> Optional[str]:

--- a/src/syrupy/location.py
+++ b/src/syrupy/location.py
@@ -54,6 +54,7 @@ class PyTestLocation:
             "modulename",
             ".".join([*test_relpath.parent.parts, test_relpath.stem]),
         )
+        object.__setattr__(self, "methodname", None)
         object.__setattr__(
             self, "nodename", test_node.replace(f"{self.modulename}.", "")
         )

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -46,6 +46,10 @@ class ItemStatus(Enum):
     SKIPPED = "skipped"
 
 
+_QueuedWriteExtensionKey = Tuple[Type["AbstractSyrupyExtension"], str]
+_QueuedWriteTestLocationKey = Tuple["PyTestLocation", "SnapshotIndex"]
+
+
 @dataclass
 class SnapshotSession:
     pytest_session: "pytest.Session"
@@ -63,8 +67,8 @@ class SnapshotSession:
     )
 
     _queued_snapshot_writes: Dict[
-        Tuple[Type["AbstractSyrupyExtension"], str],
-        Dict[Tuple["PyTestLocation", "SnapshotIndex"], "SerializedData"],
+        _QueuedWriteExtensionKey,
+        Dict[_QueuedWriteTestLocationKey, "SerializedData"],
     ] = field(default_factory=dict)
 
     def _snapshot_write_queue_key(
@@ -72,7 +76,7 @@ class SnapshotSession:
         extension: "AbstractSyrupyExtension",
         test_location: "PyTestLocation",
         index: "SnapshotIndex",
-    ) -> Tuple[Type["AbstractSyrupyExtension"], str]:
+    ) -> _QueuedWriteExtensionKey:
         snapshot_location = extension.get_location(
             test_location=test_location, index=index
         )

--- a/tests/integration/test_snapshot_diff.py
+++ b/tests/integration/test_snapshot_diff.py
@@ -1,0 +1,56 @@
+import pytest
+
+_TEST = """
+def test_foo(snapshot):
+    assert {**base} == snapshot(name="a")
+    assert {**base, **extra} == snapshot(name="b", diff="a")
+"""
+
+
+def _make_file(testdir, base, extra):
+    testdir.makepyfile(
+        test_file="\n\n".join([f"base = {base!r}", f"extra = {extra!r}", _TEST])
+    )
+
+
+def _run_test(testdir, base, extra, expected_update_lines):
+    _make_file(testdir, base=base, extra=extra)
+
+    # Run with --snapshot-update, to generate/update snapshots:
+    result = testdir.runpytest(
+        "-v",
+        "--snapshot-update",
+    )
+    result.stdout.re_match_lines((expected_update_lines,))
+    assert result.ret == 0
+
+    # Run without --snapshot-update, to validate the snapshots are actually up-to-date
+    result = testdir.runpytest("-v")
+    result.stdout.re_match_lines((r"2 snapshots passed\.",))
+    assert result.ret == 0
+
+
+def test_diff_lifecycle(testdir) -> pytest.Testdir:
+    # first: create both snapshots completely from scratch
+    _run_test(
+        testdir,
+        base={"A": 1},
+        extra={"X": 10},
+        expected_update_lines=r"2 snapshots generated\.",
+    )
+
+    # second: edit the base data, to change the data for both snapshots (only changes the serialized output for the base snapshot `a`).
+    _run_test(
+        testdir,
+        base={"A": 1, "B": 2},
+        extra={"X": 10},
+        expected_update_lines=r"1 snapshot passed. 1 snapshot updated\.",
+    )
+
+    # third: edit just the extra data (only changes the serialized output for the diff snapshot `b`)
+    _run_test(
+        testdir,
+        base={"A": 1, "B": 2},
+        extra={"X": 10, "Y": 20},
+        expected_update_lines=r"1 snapshot passed. 1 snapshot updated\.",
+    )


### PR DESCRIPTION
## Description

This PR fixes `assert ... == snapshot(diff=...)` mode to work better in two scenarios:

- Adding two snapshots at the same time (i.e. not already "on disk"), where the second snapshot is a diff from the first
- Changing the base data of a diff'd snapshot

In particular, it seems like the nice performance optimisation of #606, meant the "recalling" used for diffing wasn't finding newly created or updated data, and instead just reading whatever snapshot is available on disk.

This PR resolves the problem by having the recalling managed via the `SnapshotSession`, which can thus check its write queue before reading disk.

## Related Issues

- Closes #926 

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
