### PR TITLE
fix(serializer): preserve trailing newlines in ambr serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-.vscode
 .idea
 .DS_Store
+
+# IDE
+.vscode
+!.vscode/extensions.json
+!.vscode/settings.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "littlefoxteam.vscode-python-test-adapter",
+        "ms-python.mypy-type-checker"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "pythonTestExplorer.testFramework": "pytest"
+}

--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -1,6 +1,5 @@
 import collections
 import inspect
-import os
 from collections import OrderedDict
 from types import (
     FunctionType,
@@ -124,6 +123,10 @@ class AmberDataSerializer:
                     f.write(f"{cls._marker_prefix}{cls.Marker.Name}: {snapshot.name}\n")
                     for data_line in snapshot_data.splitlines(keepends=True):
                         f.write(cls.with_indent(data_line, 1))
+                    if data_line.endswith("\n"):
+                        # splitlines does not split on a terminal/trailing newline, so we must
+                        # account for that manually
+                        f.write(cls.with_indent("", 1))
                     f.write(f"\n{cls._marker_prefix}{cls.Marker.Divider}\n")
 
     @classmethod
@@ -168,7 +171,9 @@ class AmberDataSerializer:
                             if test_name and snapshot_data:
                                 yield Snapshot(
                                     name=test_name,
-                                    data=snapshot_data.rstrip(os.linesep),
+                                    data=snapshot_data.removesuffix("\r\n")
+                                    if snapshot_data.endswith("\r\n")
+                                    else snapshot_data.removesuffix("\n"),
                                     tainted=tainted,
                                 )
                             test_name = None

--- a/tests/syrupy/extensions/amber/__snapshots__/test_amber_newlines.ambr
+++ b/tests/syrupy/extensions/amber/__snapshots__/test_amber_newlines.ambr
@@ -1,0 +1,19 @@
+# serializer version: 1
+# name: test_multiline_repr
+  Line1
+  Line2
+  
+  Line3 
+# ---
+# name: test_trailing_2_newlines_in_repr
+  ReprWithNewline
+  
+  
+# ---
+# name: test_trailing_newline_in_repr
+  ReprWithNewline
+  
+# ---
+# name: test_trailing_no_newline_in_repr
+  ReprWithNewline
+# ---

--- a/tests/syrupy/extensions/amber/test_amber_newlines.py
+++ b/tests/syrupy/extensions/amber/test_amber_newlines.py
@@ -1,0 +1,34 @@
+class ReprWithNewline:
+    def __init__(self, newlines: int = 1) -> None:
+        self.newlines = newlines
+
+    def __repr__(self) -> str:
+        newlines = "\n" * self.newlines
+        return f"ReprWithNewline{newlines}"
+
+
+def test_trailing_no_newline_in_repr(snapshot):
+    assert ReprWithNewline(0) == snapshot
+
+
+def test_trailing_newline_in_repr(snapshot):
+    assert ReprWithNewline(1) == snapshot
+
+
+def test_trailing_2_newlines_in_repr(snapshot):
+    assert ReprWithNewline(2) == snapshot
+
+
+class MultilineRepr:
+    def __repr__(self) -> str:
+        return "\n".join(
+            [
+                "Line1",
+                "Line2\n",  # extra newline
+                "Line3 ",  # with an extra space
+            ]
+        )
+
+
+def test_multiline_repr(snapshot):
+    assert MultilineRepr() == snapshot


### PR DESCRIPTION
BREAKING CHANGE: Trailing newlines are now preserved in amber serialization. This mostly affects serialization of custom repr implementations.

Closes #925 