### PR TITLE
fix(serializer): raise TypeError when serializing non-byte like object in binary mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Syrupy comes with a few built-in preset configurations for you to choose from. Y
 
 - **`AmberSnapshotExtension`**: This is the default extension which generates `.ambr` files. Serialization of most data types are supported.
   - Line control characters are normalised when snapshots are generated i.e. `\r` and `\n` characters are all written as `\n`. This is to allow interoperability of snapshots between operating systems that use disparate line control characters.
-- **`SingleFileSnapshotExtension`**: Unlike the `AmberSnapshotExtension`, which groups all tests within a single test file into a singular snapshot file, this extension creates one `.raw` file per test case.
+- **`SingleFileSnapshotExtension`**: Unlike the `AmberSnapshotExtension`, which groups all tests within a single test file into a singular snapshot file, this extension creates one `.raw` file per test case. Note that the default behaviour of the SingleFileSnapshotExtension is to write raw bytes to disk. There is no further "serialization" that happens. For this reason, it is not a direct replacement for the Amber extension. The `SingleFileSnapshotExtension` is mostly used as a building block for other extensions such as the image extensions as well as the JSON extension. In the default "binary" mode, attempting to serialize a non-byte-like object will throw a TypeError.
 - **`PNGImageSnapshotExtension`**: An extension of single file, this should be used to produce `.png` files from a byte string.
 - **`SVGImageSnapshotExtension`**: Another extension of single file. This produces `.svg` files from an svg string.
 - **`JSONSnapshotExtension`**: Another extension of single file. This produces `.json` files from dictionaries and lists.

--- a/src/syrupy/extensions/single_file.py
+++ b/src/syrupy/extensions/single_file.py
@@ -50,7 +50,17 @@ class SingleFileSnapshotExtension(AbstractSyrupyExtension):
         include: Optional["PropertyFilter"] = None,
         matcher: Optional["PropertyMatcher"] = None,
     ) -> "SerializedData":
-        return self.get_supported_dataclass()(data)
+        supported_dataclass = self.get_supported_dataclass()
+        if supported_dataclass is bytes:
+            try:
+                memoryview(data)
+            except TypeError:
+                raise TypeError(
+                    gettext(
+                        "Can't serialize '{}' to '{}'. You must convert the data first."
+                    ).format(type(data).__name__, supported_dataclass.__name__)
+                ) from None
+        return supported_dataclass(data)
 
     @classmethod
     def get_snapshot_name(

--- a/tests/integration/test_invalid_bytes_single_file.py
+++ b/tests/integration/test_invalid_bytes_single_file.py
@@ -1,0 +1,15 @@
+def test_raises_informative_type_error_when_serializing_non_bytes(testdir):
+    testdir.makepyfile(
+        test_file="""
+        from syrupy.extensions.single_file import SingleFileSnapshotExtension
+
+        def test_case(snapshot):
+            assert {"x": 0} == snapshot(extension_class=SingleFileSnapshotExtension)
+        """
+    )
+
+    result = testdir.runpytest("-v")
+    assert result.ret == 1
+    result.stdout.re_match_lines(
+        (r".*TypeError: Can't serialize.*You must convert the data.*",)
+    )


### PR DESCRIPTION
Improves docs + error message.

Closes #749 