### PR TITLE
Avoid unnecessary env updates to reduce chances of segfault

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import contextlib
 import sys
 from functools import lru_cache
 from gettext import gettext
@@ -105,11 +106,14 @@ def pytest_addoption(parser: "pytest.Parser") -> None:
 
 
 def __terminal_color(config: "pytest.Config") -> "ContextManager[None]":
-    env = {}
     if config.option.no_colors:
-        env[DISABLE_COLOR_ENV_VAR] = "true"
-
-    return env_context(**env)
+        env = {
+            DISABLE_COLOR_ENV_VAR: "true",
+        }
+        return env_context(**env)
+    else:
+        # No-op to avoid unnecessary env updates
+        return contextlib.nullcontext()
 
 
 def pytest_assertrepr_compare(

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -123,7 +123,9 @@ def pytest_assertrepr_compare(
     Return explanation for comparisons in failing assert expressions.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_assertrepr_compare
     """
-    if not isinstance(left, SnapshotAssertion) and not isinstance(right, SnapshotAssertion):
+    if not isinstance(left, SnapshotAssertion) and not isinstance(
+        right, SnapshotAssertion
+    ):
         # Shortcut to minimise overhead in the case of other unrelated assertions
         return None
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -123,6 +123,10 @@ def pytest_assertrepr_compare(
     Return explanation for comparisons in failing assert expressions.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_assertrepr_compare
     """
+    if not isinstance(left, SnapshotAssertion) and not isinstance(right, SnapshotAssertion):
+        # Shortcut to minimise overhead in the case of other unrelated assertions
+        return None
+
     with __terminal_color(config):
         received_name = received_style("[+ received]")
 


### PR DESCRIPTION
## Description

This PR reduces unnecessary calls to `os.environ.update` (via `env_context`) in order to reduce the probability of a segmentation fault caused by a race with `getenv` in another thread as described by https://github.com/syrupy-project/syrupy/issues/955

## Related Issues

- The single related issue I'm aware of is https://github.com/syrupy-project/syrupy/issues/955 and:
  - this PR should significantly mitigate that issue
  - however there are still cases in which `os.environ` is modified (when `assert` compares 2 `SnapshotAssertion` instances and `--snapshot-no-colors` is enabled) so I'm not sure this PR should be marked as one taht "fixes" that issue
  - a more full solution may be to avoid setting the env at all if it's possible to replace this with use of `contextvars` instead?

## Checklist

- [x] This PR has sufficient documentation -- I think so; it is a bugfix with sufficient explanation in the commit messages
- [ ] This PR has sufficient test coverage -- not yet, I can add this if desired though it will be quite contrived I think
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

Applying this patch locally allowed our playwright test run to complete 200 full runs with zero segfaults (whereas previously it was segfaulting roughly once on every 5-15 runs).