### PR TITLE
fix: snapshots of deselected parametrized tests wrongly marked as unused

### DIFF
--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -281,7 +281,7 @@ class SnapshotReport:
         """
         These are the lines printed at the end of a test run. Example:
         ```
-        2 snaphots passed. 5 snapshots generated. 1 unused snapshot deleted.
+        2 snapshots passed. 5 snapshots generated. 1 unused snapshot deleted.
 
         Re-run pytest with --snapshot-update to delete unused snapshots.
         ```

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -183,13 +183,13 @@ class SnapshotSession:
 
         if is_xdist_worker():
             # TODO: If we're in a pytest-xdist worker, we need to combine the reports
-            # of all the workers so that the controller can handle unused
-            # snapshot removal.
+            #  of all the workers so that the controller can handle unused
+            #  snapshot removal.
             return exitstatus
         elif is_xdist_controller():
             # TODO: If we're in a pytest-xdist controller, merge all the reports.
-            # Until this is implemented, running syrupy with pytest-xdist is only
-            # partially functional.
+            #  Until this is implemented, running syrupy with pytest-xdist is only
+            #  partially functional.
             return exitstatus
 
         if self.report.num_unused:

--- a/tests/integration/test_snapshot_option_update.py
+++ b/tests/integration/test_snapshot_option_update.py
@@ -301,7 +301,7 @@ def test_update_targets_only_selected_class_tests_dash_k(
         "test_content.py", "-v", *plugin_args_fails_xdist, "-k", "test_case_2"
     )
     result.stdout.re_match_lines((r"1 snapshot passed\.",))
-    assert "snaphot unused" not in result.stdout.str()
+    assert "snapshot unused" not in result.stdout.str()
 
 
 def test_update_targets_only_selected_module_tests_dash_k(
@@ -325,7 +325,7 @@ def test_update_targets_only_selected_module_tests_dash_k(
         "test_content.py", "-v", *plugin_args_fails_xdist, "-k", "test_case_2"
     )
     result.stdout.re_match_lines((r"1 snapshot passed\.",))
-    assert "snaphot unused" not in result.stdout.str()
+    assert "snapshot unused" not in result.stdout.str()
 
 
 def test_update_targets_only_selected_module_tests_nodes(

--- a/tests/syrupy/test_location.py
+++ b/tests/syrupy/test_location.py
@@ -3,13 +3,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from syrupy.constants import PYTEST_NODE_SEP
 from syrupy.location import PyTestLocation
 
 
 def mock_pytest_item(node_id: str, method_name: str) -> "pytest.Item":
     mock_node = MagicMock(spec=pytest.Item)
     mock_node.nodeid = node_id
-    [filepath, *_, nodename] = node_id.split("::")
+    [filepath, *_, nodename] = node_id.split(PYTEST_NODE_SEP)
     mock_node.name = nodename
     mock_node.path = Path(filepath)
     mock_node.obj = MagicMock()
@@ -20,7 +21,7 @@ def mock_pytest_item(node_id: str, method_name: str) -> "pytest.Item":
 
 @pytest.mark.parametrize(
     "node_id, method_name, expected_filename,"
-    "expected_classname,expected_snapshotname",
+    "expected_classname, expected_snapshotname",
     (
         (
             "/tests/module/test_file.py::TestClass::method_name",
@@ -86,7 +87,13 @@ def test_location_properties(
         (
             "/tests/module/test_file.py::TestClass::method_name[1]",
             "method_name",
-            ("test_file.snap", "__snapshots__/test_file", "test_file/1.snap"),
+            (
+                "test_file.snap",
+                "__snapshots__/test_file",
+                "test_file/TestClass.method_name[1].snap",
+                "test_file/TestClass.method_name[1].1.snap",
+                "test_file/TestClass.method_name[1][1].snap",
+            ),
             (
                 "test.snap",
                 "__others__/test/file.snap",
@@ -95,11 +102,15 @@ def test_location_properties(
                 "test_file_extra/1.snap",
                 "test_file/extra/1.snap",
                 "__snapshots__/test_file/extra/even/more/1.snap",
+                "test_file/TestClass.method_name[1]xyz.snap",
+                "test_file/TestClass.method_name[2].snap",
             ),
             (
                 "TestClass.method_name",
                 "TestClass.method_name[1]",
                 "TestClass.method_name.1",
+                "TestClass.method_name[1][1]",
+                "TestClass.method_name[1].1",
             ),
             ("method_name", "TestClass.method_names"),
         ),


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

This PR fixes a bug where the snapshots of deselected parametrized tests are wrongly marked as unused.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #918.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.