### PR TITLE
fix(serializer): preserve trailing newlines in ambr serialization (#950)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-.vscode
 .idea
 .DS_Store
+
+# IDE
+.vscode
+!.vscode/extensions.json
+!.vscode/settings.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "littlefoxteam.vscode-python-test-adapter",
+        "ms-python.mypy-type-checker"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "pythonTestExplorer.testFramework": "pytest"
+}

--- a/tests/syrupy/extensions/amber/__snapshots__/test_amber_newlines.ambr
+++ b/tests/syrupy/extensions/amber/__snapshots__/test_amber_newlines.ambr
@@ -1,0 +1,19 @@
+# serializer version: 1
+# name: test_multiline_repr
+  Line1
+  Line2
+  
+  Line3 
+# ---
+# name: test_trailing_2_newlines_in_repr
+  ReprWithNewline
+  
+  
+# ---
+# name: test_trailing_newline_in_repr
+  ReprWithNewline
+  
+# ---
+# name: test_trailing_no_newline_in_repr
+  ReprWithNewline
+# ---

--- a/tests/syrupy/extensions/amber/test_amber_newlines.py
+++ b/tests/syrupy/extensions/amber/test_amber_newlines.py
@@ -1,0 +1,34 @@
+class ReprWithNewline:
+    def __init__(self, newlines: int = 1) -> None:
+        self.newlines = newlines
+
+    def __repr__(self) -> str:
+        newlines = "\n" * self.newlines
+        return f"ReprWithNewline{newlines}"
+
+
+def test_trailing_no_newline_in_repr(snapshot):
+    assert ReprWithNewline(0) == snapshot
+
+
+def test_trailing_newline_in_repr(snapshot):
+    assert ReprWithNewline(1) == snapshot
+
+
+def test_trailing_2_newlines_in_repr(snapshot):
+    assert ReprWithNewline(2) == snapshot
+
+
+class MultilineRepr:
+    def __repr__(self) -> str:
+        return "\n".join(
+            [
+                "Line1",
+                "Line2\n",  # extra newline
+                "Line3 ",  # with an extra space
+            ]
+        )
+
+
+def test_multiline_repr(snapshot):
+    assert MultilineRepr() == snapshot


### PR DESCRIPTION
Trailing newlines are now preserved in amber serialization. This mostly affects serialization of custom repr implementations.

Related:
- #925 
- #964

Pulling this out of v5 into v4. Considering the behaviour is somewhat broken, I'm not considering this a breaking change.