### PR TITLE
fix: Block terminal summary for xdist workers.

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -26,6 +26,7 @@ from .terminal import (
 from .utils import (
     env_context,
     import_module_member,
+    is_xdist_worker,
 )
 
 # Global to have access to the session in `pytest_runtest_logfinish` hook
@@ -213,6 +214,12 @@ def pytest_terminal_summary(
     Add syrupy report to pytest.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_terminal_summary
     """
+    if is_xdist_worker():
+        # There is no need for pytest-xdist worker processes to generate a
+        # summary and doing so has been seen to cause CPU spin and delays to
+        # test run shutdown.
+        return
+
     with __terminal_color(config):
         is_printing_report = False
         for line in terminalreporter.config._syrupy.report.lines:


### PR DESCRIPTION
## Description

This PR prevents pytest_terminal_summary from executing in pytest-xdist worker processes.

I have seen this cause workers to use very high CPU (100% of a core or close) and cause a significant delay at the end of test runs (about 5 seconds).

I cannot see any reason why xdist worker should need to run the terminal summary, so simply preventing execution seems to be a sensible solution. Of course I may be wrong about this.

All tests appear to still pass. It is not obvious to me how to add a test for this change, but I do not think it is really necessary.

## Related Issues

None.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ n/a] This PR has sufficient documentation.
- [ ] This PR has sufficient test coverage.
- [ x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
