### PR TITLE
fix: ensure `syrupy`'s `pytest_assertrepr_compare` hook is called first.

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -123,12 +123,13 @@ def __terminal_color(
         return contextlib.nullcontext()
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_assertrepr_compare(
     config: "pytest.Config", op: str, left: Any, right: Any
 ) -> Optional[list[str]]:
     """
     Return explanation for comparisons in failing assert expressions.
-    https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_assertrepr_compare
+    https://docs.pytest.org/en/latest/reference.html#pytest.hookspec.pytest_assertrepr_compare
     """
     if not isinstance(left, SnapshotAssertion) and not isinstance(
         right, SnapshotAssertion


### PR DESCRIPTION
## Description

When using `syrupy` with [pytest-clarity](https://github.com/darrenburns/pytest-clarity/) the `pytest_assertrepr_compare` is called from `pytest-clarity`. This PR ensure `syrupy`'s `pytest_assertrepr_compare` is called first which gives it the ability to handle `SnapshotAssertion` before any other plugin. The code already does an early exit if the `left` or `right` value(s) are not `SnapshotAssertion` and automatically falling back to any other plugin that implements `pytest_assertrepr_compare`.

## Related Issues

N/A

## Checklist

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

No additional comments.
