### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,9 @@ env:
 jobs:
   release:
     name: Release
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     environment: release
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/syrupy-project/syrupy/security/code-scanning/1](https://github.com/syrupy-project/syrupy/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or the specific job. The block should grant only the minimum required permissions for the workflow to function. For a release workflow using `semantic-release`, the most common requirements are `contents: write` (to create tags/releases and push changes) and possibly `pull-requests: write` (if the workflow creates or updates pull requests). If you know the workflow only needs to read contents, you can set `contents: read`, but in this case, write access is likely needed. The best place to add the block is at the job level (under `jobs.release:`), but you can also add it at the root if you want it to apply to all jobs. Edit `.github/workflows/release.yaml` and add the following under `jobs.release:` (after `name: Release`):

```yaml
permissions:
  contents: write
  pull-requests: write
```

This ensures the job only has the permissions it needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
