### PR TITLE
feat: allow empty lines in snapshot

### DIFF
--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -1,5 +1,6 @@
 import collections
 import inspect
+import textwrap
 from collections import OrderedDict
 from collections.abc import Callable, Generator, Iterable
 from types import (
@@ -184,6 +185,9 @@ class AmberDataSerializer:
                             snapshot_data = ""
                     elif test_name is not None and line.startswith(cls._indent):
                         snapshot_data += line[indent_len:]
+                    elif test_name is not None and line.strip() == "":
+                        # Remove trailing whitespace (but not newline character) from empty line.
+                        snapshot_data += textwrap.dedent(line)
         except FileNotFoundError:
             pass
         else:

--- a/tests/syrupy/extensions/amber/__snapshots__/test_amber_newlines.ambr
+++ b/tests/syrupy/extensions/amber/__snapshots__/test_amber_newlines.ambr
@@ -4,6 +4,14 @@
   Line2
   
   Line3 
+  
+# ---
+# name: test_multiline_repr_with_no_indentation
+  Line1
+  Line2
+
+  Line3 
+
 # ---
 # name: test_trailing_2_newlines_in_repr
   ReprWithNewline

--- a/tests/syrupy/extensions/amber/test_amber_newlines.py
+++ b/tests/syrupy/extensions/amber/test_amber_newlines.py
@@ -35,7 +35,7 @@ def test_multiline_repr(snapshot):
     assert MultilineRepr() == snapshot
 
 
-def test_multiline_repr_with_no_indentation(snapshot):
+def test_multiline_repr_with_missing_indentation_on_empty_lines(snapshot):
     # snapshot file has been manually edited
-    # remove newlines from this test if you update the snapshot
+    # remove spaces from newlines from this test if you update the snapshot
     assert MultilineRepr() == snapshot

--- a/tests/syrupy/extensions/amber/test_amber_newlines.py
+++ b/tests/syrupy/extensions/amber/test_amber_newlines.py
@@ -26,9 +26,16 @@ class MultilineRepr:
                 "Line1",
                 "Line2\n",  # extra newline
                 "Line3 ",  # with an extra space
+                "",  # newline at end
             ]
         )
 
 
 def test_multiline_repr(snapshot):
+    assert MultilineRepr() == snapshot
+
+
+def test_multiline_repr_with_no_indentation(snapshot):
+    # snapshot file has been manually edited
+    # remove newlines from this test if you update the snapshot
     assert MultilineRepr() == snapshot


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

This PR allows empty lines in the snapshot file to be treated that way, without affecting other snapshot semantics.

## Example
Say I have a test output that looks like this:
```markdown
# Outputs README-like text

Including empty newlines above and below

<footer>Followed by a footer</footer>
```

This is saved in a snapshot as:
```python
  """
  # Outputs README-like text
  
  Including empty newlines above and below
  
  <footer>Followed by a footer</footer>
  """
```
Therefore, there are two lines in this snapshot that include just spaces: `"  "`.
This PR does not affect how the snapshots are saved, but if you trim the empty spaces on the blank lines, such as with a linting tool, the snapshot will load them as empty lines (currently, they are skipped).

## Related Issues

- closes #619, which asks for this feature

## Checklist

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

No additional comments.
