### PR TITLE
fix: include tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,11 @@ default-groups = [
 ]
 
 [tool.hatch.build.targets.sdist]
-include = ["src/syrupy"]
+include = [
+    "conftest.py",
+    "src/syrupy",
+    "tests",
+]
 
 [tool.hatch.build.targets.wheel]
 include = ["src/syrupy"]


### PR DESCRIPTION
Summary
- Includes the test suite and root `conftest.py` in the source distribution.
- Keeps the wheel contents unchanged.
- Fixes the packaging gap reported in #1092 so downstream packagers can run tests from the sdist.

Validation
- `python -m hatchling build -t sdist -d ..\tmp\syrupy-baseline-sdist` before the change showed 0 `tests/` entries and no root `conftest.py` in the sdist.
- `python -m hatchling build -t sdist -d ..\tmp\syrupy-final-sdist` passed after the change.
- Tarball inspection after the change found 187 `tests/` entries, root `conftest.py`, `tests/conftest.py`, and representative test files in the sdist.
- `python -X utf8 -m pytest tests -q` passed: 376 passed, 60 xfailed, 6 xpassed.
- `git diff --check` passed.

Notes
- Closes #1092.
- No runtime package or wheel content changes are intended.
