### PR TITLE
perf: avoid copying the cycle-detection set on every serialized node

### DIFF
--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -274,21 +274,29 @@ class AmberDataSerializer:
     ) -> str:
         visited = set() if visited is None else visited
         data_id = id(data)
-        if depth > cls._max_depth or data_id in visited:
+        # Track ancestors in one shared set and unwind after recursing, instead
+        # of copying the set at every node.
+        already_visited = data_id in visited
+        if depth > cls._max_depth or already_visited:
             data = Repr(SYMBOL_ELLIPSIS)
         elif matcher:
             data = matcher(data=data, path=path)
-        serialize_kwargs = {
-            "data": data,
-            "depth": depth,
-            "exclude": exclude,
-            "include": include,
-            "matcher": matcher,
-            "path": path,
-            "visited": {*visited, data_id},
-        }
-        serialize_method = cls._assign_serialize_method(data)
-        return serialize_method(**serialize_kwargs)
+        if not already_visited:
+            visited.add(data_id)
+        try:
+            serialize_method = cls._assign_serialize_method(data)
+            return serialize_method(
+                data=data,
+                depth=depth,
+                exclude=exclude,
+                include=include,
+                matcher=matcher,
+                path=path,
+                visited=visited,
+            )
+        finally:
+            if not already_visited:
+                visited.discard(data_id)
 
     @classmethod
     def _assign_serialize_method(cls, data: "SerializableData") -> Callable[..., str]:


### PR DESCRIPTION
## Description

`_serialize` recurses through the whole object graph and keeps a `visited` set of the ids of all ancestors on the current path, used to detect cycles and collapse them to `...`. It rebuilt that set at every single node with `{*visited, data_id}`, so a snapshot of N values did N set allocations, each copying the current path.

This switches to backtracking a single shared set: add the current id before recursing, discard it afterwards in a `finally`. The `already_visited` guard makes sure that when a real cycle is hit (the id is already in the set from an ancestor), we neither re-add nor discard it, so the ancestor stays marked for its remaining children. Net effect is the same cycle detection with one set mutated in place instead of one allocation per node.

Output is byte-identical, so existing snapshots are unaffected. Cycles still collapse to `...`, and an object that legitimately appears more than once without being its own ancestor (shared, not cyclic) is still serialized in full each time.

On a representative nested payload (2000 nested state dicts, ~1.3 MB of serialized output) this is roughly 13% faster serialization in an in-process A/B. The gain grows with the size and depth of the data.

Reproduction:

```python
import timeit
from syrupy.extensions.amber.serializer import AmberDataSerializer as S

def make_state(i):
    return {
        "entity_id": f"sensor.thing_{i}",
        "state": str(i % 100),
        "attributes": {
            "friendly_name": f"Thing {i}",
            "unit_of_measurement": "W",
            "device_class": "power",
            "extra": [1, 2, 3, {"a": i, "b": [i, i + 1, i + 2]}],
        },
        "last_changed": "2024-01-01T00:00:00+00:00",
        "context": {"id": f"{i:032d}", "parent_id": None, "user_id": None},
    }

data = [make_state(i) for i in range(2000)]
n = 10
print(min(timeit.repeat(lambda: S.serialize(data), number=n, repeat=8)) / n * 1000, "ms")
```

## Related Issues

No related issue. This is a self-contained performance improvement.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

The existing cycle and shared-object tests already cover this, and serialized output stays byte-identical, so the change is behavior-preserving. It pairs naturally with the string-serialization speedup in #1118 but stands on its own.
