### PR TITLE
fix: avoid os.environ mutation for color control

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,22 @@
-import pytest
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 
-from syrupy.utils import env_context
+import pytest
 
 pytest_plugins = "pytester"
 
 
+@contextmanager
+def _env_context(**kwargs: str) -> Iterator[None]:
+    prev_env = {**os.environ}
+    try:
+        yield os.environ.update(kwargs)
+    finally:
+        os.environ.clear()
+        os.environ.update(prev_env)
+
+
 @pytest.fixture
 def osenv():
-    return env_context
+    return _env_context

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -14,19 +14,18 @@ import pytest
 from syrupy.extensions.base import SnapshotCollectionStorage
 
 from .assertion import DiffMode, SnapshotAssertion
-from .constants import DISABLE_COLOR_ENV_VAR
 from .exceptions import FailedToLoadModuleMember
 from .extensions import DEFAULT_EXTENSION
 from .location import PyTestLocation
 from .patches.pycharm_diff import patch_pycharm_diff
 from .session import SnapshotSession
 from .terminal import (
+    disable_color,
     received_style,
     reset,
     snapshot_style,
 )
 from .utils import (
-    env_context,
     import_module_member,
     is_xdist_worker,
 )
@@ -129,12 +128,9 @@ def __terminal_color(
     config: "pytest.Config",
 ) -> "contextlib.AbstractContextManager[None]":
     if config.option.no_colors:
-        env = {
-            DISABLE_COLOR_ENV_VAR: "true",
-        }
-        return env_context(**env)
+        return disable_color()
     else:
-        # No-op to avoid unnecessary env updates
+        # No-op to avoid unnecessary work
         return contextlib.nullcontext()
 
 

--- a/src/syrupy/extensions/base.py
+++ b/src/syrupy/extensions/base.py
@@ -13,7 +13,6 @@ from typing import (
 )
 
 from syrupy.constants import (
-    DISABLE_COLOR_ENV_VAR,
     SYMBOL_CARRIAGE,
     SYMBOL_ELLIPSIS,
     SYMBOL_NEW_LINE,
@@ -28,6 +27,7 @@ from syrupy.data import (
 from syrupy.exceptions import SnapshotDoesNotExist
 from syrupy.terminal import (
     context_style,
+    disable_color,
     received_diff_style,
     received_style,
     reset,
@@ -35,7 +35,6 @@ from syrupy.terminal import (
     snapshot_style,
 )
 from syrupy.utils import (
-    env_context,
     obj_attrs,
     qdiff,
     walk_snapshot_dir,
@@ -266,9 +265,8 @@ class SnapshotReporter:
     def diff_snapshots(
         self, serialized_data: "SerializedData", snapshot_data: "SerializedData"
     ) -> "SerializedData":
-        env = {DISABLE_COLOR_ENV_VAR: "true"}
         attrs = {"_context_line_count": 0}
-        with env_context(**env), obj_attrs(self, attrs):
+        with disable_color(), obj_attrs(self, attrs):
             return "\n".join(self.diff_lines(serialized_data, snapshot_data))
 
     def diff_lines(

--- a/src/syrupy/terminal.py
+++ b/src/syrupy/terminal.py
@@ -1,11 +1,29 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 
 from .constants import DISABLE_COLOR_ENV_VARS
 from .utils import get_env_value
 
+# Toggled internally to suppress colors for a block of output. A ContextVar is
+# used instead of mutating os.environ, which is not thread safe and can segfault
+# unrelated threads that read the environment from native code.
+_disable_color: ContextVar[bool] = ContextVar("syrupy_disable_color", default=False)
+
+
+@contextmanager
+def disable_color() -> Iterator[None]:
+    """Suppress terminal colors for the duration of the context."""
+    token = _disable_color.set(True)
+    try:
+        yield
+    finally:
+        _disable_color.reset(token)
+
 
 def _is_color_disabled() -> bool:
-    return any(map(get_env_value, DISABLE_COLOR_ENV_VARS))
+    return _disable_color.get() or any(map(get_env_value, DISABLE_COLOR_ENV_VARS))
 
 
 @dataclass

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -76,16 +76,6 @@ def get_env_value(env_var_name: str) -> object:
         return os.environ.get(env_var_name)
 
 
-@contextmanager
-def env_context(**kwargs: str) -> Iterator[None]:
-    prev_env = {**os.environ}
-    try:
-        yield os.environ.update(kwargs)
-    finally:
-        os.environ.clear()
-        os.environ.update(prev_env)
-
-
 def set_attrs(obj: Any, attrs: dict[str, Any]) -> Any:
     for k in attrs:
         setattr(obj, k, attrs[k])

--- a/tests/syrupy/test_terminal.py
+++ b/tests/syrupy/test_terminal.py
@@ -1,0 +1,37 @@
+import os
+
+from syrupy.terminal import (
+    _is_color_disabled as is_color_disabled,
+)
+from syrupy.terminal import (
+    disable_color,
+    snapshot_style,
+)
+
+
+def test_disable_color_context_toggles_styling():
+    assert is_color_disabled() is False
+    styled = snapshot_style("hello")
+    assert styled != "hello"  # contains ANSI escape codes
+
+    with disable_color():
+        assert is_color_disabled() is True
+        assert snapshot_style("hello") == "hello"
+
+    # Restored after the context exits.
+    assert is_color_disabled() is False
+    assert snapshot_style("hello") == styled
+
+
+def test_disable_color_does_not_mutate_environ():
+    """Color suppression must not touch os.environ (not thread safe)."""
+    before = dict(os.environ)
+    with disable_color():
+        assert dict(os.environ) == before
+    assert dict(os.environ) == before
+
+
+def test_external_no_color_env_var_disables_color(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "true")
+    assert is_color_disabled() is True
+    assert snapshot_style("hello") == "hello"


### PR DESCRIPTION
## Description

syrupy signaled "disable color" by temporarily mutating `os.environ` (through the `env_context` helper). Mutating the environment calls glibc `setenv`, which is [not thread safe](https://www.gnu.org/software/libc/manual/html_node/Environment-Access.html) and races with `getenv` called from native code in other threads. During the `pytest_assertrepr_compare` and `diff_snapshots` paths this could segfault unrelated code, for example a database driver running in a `pytest-django` `live_server` request handler, as reported in #955.

This replaces the environment mutation with a `contextvars.ContextVar`. `terminal._is_color_disabled()` now consults that ContextVar in addition to the external `NO_COLOR` and `ANSI_COLORS_DISABLED` variables, which are still read (reads are safe, only writes race). Both call sites, `__terminal_color` (when `--snapshot-no-colors` is set) and `SnapshotReporter.diff_snapshots`, use the new `disable_color()` context manager, so no `os.environ` writes happen anywhere in the path.

The now-unused `env_context` helper is removed from `syrupy.utils`. It was undocumented and not part of `__all__`, and was the source of the race. Its only remaining user was the `osenv` test fixture, which now defines the helper locally in `conftest.py` (setting a real environment variable inside a single threaded test is fine).

#956 narrowed when the mutation happened; this removes it entirely.

## Related Issues

- Closes #955, intermittent segfaults caused by syrupy mutating `os.environ` from the assertion hook while other threads read the environment.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

New tests in `tests/syrupy/test_terminal.py` cover the toggle behavior, that the external `NO_COLOR` variable still disables color, and crucially that `disable_color()` does not touch `os.environ`. Behavior for users is unchanged: `--snapshot-no-colors`, external `NO_COLOR`/`ANSI_COLORS_DISABLED`, and the diff color suppression all work as before.
