### PR TITLE
fix: honor boolean operators in -k snapshot selection

### DIFF
--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -5,7 +5,7 @@ from dataclasses import (
     dataclass,
     field,
 )
-from functools import cached_property
+from functools import cache, cached_property
 from gettext import (
     gettext,
     ngettext,
@@ -16,6 +16,7 @@ from typing import (
     Any,
 )
 
+from _pytest.mark.expression import Expression as PytestExpression
 from _pytest.skipping import xfailed_key
 
 from .constants import PYTEST_NODE_SEP
@@ -541,24 +542,30 @@ class SnapshotReport:
         )
 
 
+@cache
+def _compile_keyword_expression(keyword: str) -> "PytestExpression":
+    return PytestExpression.compile(keyword)
+
+
 @dataclass(frozen=True)
 class Expression:
     """
-    Dumbed down version of _pytest.mark.expression.Expression not available in < 6.0
-    https://github.com/pytest-dev/pytest/blob/6.0.x/src/_pytest/mark/expression.py
-    Added for pared down support on older pytest version and because the expression
-    module is not public. This only supports inclusion based on simple string matching.
+    Evaluate a pytest ``-k`` keyword expression against snapshot names.
+
+    Delegates parsing and evaluation to pytest's own expression implementation
+    so that the ``and``/``or``/``not``/parenthesis operators behave exactly like
+    ``-k`` selection. A previous hand rolled version ignored those operators and
+    only did substring matching, which wrongly marked deselected snapshots (for
+    example ``-k 'not foo'``) as unused.
     """
 
-    code: frozenset[str] = field(default_factory=frozenset)
+    keyword: str = ""
 
     def evaluate(self, matcher: Callable[[str], bool]) -> bool:
-        return any(map(matcher, self.code))
+        # pytest's matcher protocol allows extra keyword arguments (for mark
+        # expressions); keyword matching only ever passes the positional name.
+        return _compile_keyword_expression(self.keyword).evaluate(matcher)  # type: ignore[arg-type]
 
     @staticmethod
     def compose(value: str) -> "Expression":
-        delim = " "
-        replace_str = {" or ", " and ", " not ", "(", ")"}
-        for r in replace_str:
-            value = value.replace(f" {r} ", delim)
-        return Expression(code=frozenset(value.split(delim)))
+        return Expression(keyword=value)

--- a/tests/integration/test_snapshot_option_filter_keyword.py
+++ b/tests/integration/test_snapshot_option_filter_keyword.py
@@ -1,0 +1,46 @@
+"""Regression tests for snapshot selection with the pytest ``-k`` filter.
+
+See https://github.com/syrupy-project/syrupy/issues/770: a negated keyword
+expression such as ``-k 'not one'`` deselects the matching test, and its
+snapshot must not be reported (or deleted) as obsolete.
+"""
+
+from pathlib import Path
+
+import pytest
+
+CONTENT = """
+import pytest
+
+@pytest.mark.parametrize("param", ["one", "two", "three"])
+def test_parametrized(param, snapshot):
+    assert param == snapshot
+"""
+
+
+@pytest.fixture
+def testfile(testdir):
+    testdir.makepyfile(test_file=CONTENT)
+    result = testdir.runpytest("-v", "--snapshot-update")
+    result.stdout.re_match_lines((r"3 snapshots generated\.",))
+    return testdir
+
+
+def test_positive_keyword_filter(testfile):
+    result = testfile.runpytest("-v", "-k", "one")
+    result.stdout.re_match_lines((r"1 snapshot passed\.",))
+    assert "snapshot unused" not in result.stdout.str()
+
+
+def test_negated_keyword_filter(testfile):
+    result = testfile.runpytest("-v", "-k", "not one")
+    result.stdout.re_match_lines((r"2 snapshots passed\.",))
+    assert "snapshot unused" not in result.stdout.str()
+
+
+def test_negated_keyword_filter_update_keeps_snapshot(testfile):
+    result = testfile.runpytest("-v", "--snapshot-update", "-k", "not one")
+    assert "Deleted" not in result.stdout.str()
+
+    snapshot_file = Path(testfile.tmpdir, "__snapshots__", "test_file.ambr")
+    assert "test_parametrized[one]" in snapshot_file.read_text()


### PR DESCRIPTION
## Description

syrupy reimplemented the pytest `-k` keyword expression with a hand rolled matcher (`report.Expression`) that flattened the expression into a set of tokens and returned true if any token was a substring of the snapshot name. This ignored the `and`/`or`/`not` and parenthesis operators entirely.

As a result, a negated expression like `-k 'not one'` treated `one` as a positive match, so the deselected `test_parametrized[one]` snapshot was considered unused. On a normal run that reports a spurious unused snapshot (and fails the suite), and with `--snapshot-update` the snapshot is then deleted, which is data loss.

Minimal reproduction (from #770), no `pytest-bdd` required:

```python
import pytest

@pytest.mark.parametrize("param", ["one", "two", "three"])
def test_parametrized(param, snapshot):
    assert param == snapshot
```

```
pytest --snapshot-update          # writes 3 snapshots
pytest -k 'not one'               # before: "1 snapshot unused"; after: clean
pytest --snapshot-update -k 'not one'   # before: deletes test_parametrized[one]
```

This delegates parsing and evaluation to pytest's own `_pytest.mark.expression.Expression`, so selection matches `-k` exactly, including boolean operators and parentheses. syrupy already requires `pytest >= 8`, and `report.py` already imports from `_pytest` (`_pytest.skipping`), so this does not introduce a new kind of dependency. Compiled expressions are cached.

## Related Issues

- Closes #770, unused snapshots incorrectly detected (and deleted on update) when filtering with a negated or compound `-k` expression.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

Added regression tests in `tests/integration/test_snapshot_option_filter_keyword.py` covering a positive filter, a negated filter, and a negated filter under `--snapshot-update` (asserting the deselected snapshot is kept). The two negated cases fail on `main` and pass with this change. Bracket and dash keyword forms that the existing tests rely on (for example `-k 'test_used['`) keep working, since pytest's parser accepts them as substring matchers. One `# type: ignore[arg-type]` is needed where syrupy's `Callable[[str], bool]` matcher meets pytest's keyword-argument-tolerant matcher protocol; keyword matching only ever passes the positional name.
