### PR TITLE
feat: detect unused snapshots under pytest-xdist

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ See [#675](https://github.com/syrupy-project/syrupy/issues/675) for the original
 
 ## Known Limitations
 
-- `pytest-xdist` support only partially exists. There is no issue when it comes to reads however when you attempt to run `pytest --snapshot-update`, if running with more than 1 process, the ability to detect unused snapshots is disabled. See [#535](https://github.com/syrupy-project/syrupy/issues/535) for more information.
+- `pytest-xdist`: unused snapshot detection and removal are supported when running with multiple processes. Each worker reports the snapshots it used and the controller combines them to determine which snapshots are unused. See [#535](https://github.com/syrupy-project/syrupy/issues/535) for more information.
 
 _We welcome contributions to patch these known limitations._
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -210,6 +210,20 @@ def pytest_collection_finish(session: Any) -> None:
     session.config._syrupy.select_items(session.items)
 
 
+def pytest_testnodedown(node: Any, error: Any) -> None:
+    """
+    Collect a pytest-xdist worker's snapshot report as the worker shuts down.
+    Runs on the controller; the payload is published via ``config.workeroutput``.
+    https://pytest-xdist.readthedocs.io/en/stable/distribution.html
+    """
+    workeroutput = getattr(node, "workeroutput", None)
+    syrupy = getattr(node.config, "_syrupy", None)
+    if workeroutput and syrupy:
+        report = workeroutput.get("syrupy_report")
+        if report is not None:
+            syrupy.add_worker_report(report)
+
+
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     """
     After each of the setup, call and teardown runtest phases of an item.

--- a/src/syrupy/data.py
+++ b/src/syrupy/data.py
@@ -122,6 +122,21 @@ class SnapshotCollections:
     def __contains__(self, key: str) -> bool:
         return key in self._snapshot_collections
 
+    def serialize(self) -> dict[str, list[str]]:
+        """Reduce to a ``{location: [snapshot name, ...]}`` mapping for transport."""
+        return {
+            location: [snapshot.name for snapshot in collection]
+            for location, collection in self._snapshot_collections.items()
+        }
+
+    def merge_serialized(self, data: dict[str, list[str]]) -> None:
+        """Merge a mapping produced by :meth:`serialize` into this instance."""
+        for location, names in data.items():
+            collection = SnapshotCollection(location=location)
+            for name in names:
+                collection.add(Snapshot(name=name))
+            self.update(collection)
+
 
 @dataclass
 class DiffedLine:

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -1,3 +1,4 @@
+import os
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import (
@@ -17,6 +18,7 @@ import pytest
 
 from .constants import EXIT_STATUS_FAIL_UNUSED
 from .data import SnapshotCollections
+from .exceptions import FailedToLoadModuleMember
 from .location import PyTestLocation
 from .report import SnapshotReport
 from .types import (
@@ -24,9 +26,36 @@ from .types import (
     SnapshotIndex,
 )
 from .utils import (
-    is_xdist_controller,
+    import_module_member,
     is_xdist_worker,
 )
+
+# Snapshot collections on the report that are merged across pytest-xdist workers.
+_MERGED_COLLECTIONS = ("discovered", "created", "failed", "matched", "updated", "used")
+
+
+class _ReconstructedObject:
+    """Stand-in for ``item.obj`` rebuilt from a worker's serialized item."""
+
+    def __init__(self, modulename: str, methodname: str) -> None:
+        self.__module__ = modulename
+        self.__name__ = methodname
+
+
+class _ReconstructedItem:
+    """
+    Stand-in for a ``pytest.Item`` rebuilt on the controller from a worker.
+
+    The controller never collects items itself, so to reuse the regular unused
+    snapshot detection we recreate just enough of the pytest item for
+    ``PyTestLocation`` to resolve snapshot names and locations.
+    """
+
+    def __init__(self, data: dict[str, str]) -> None:
+        self.nodeid = data["nodeid"]
+        self.name = data["name"]
+        self.path = Path(data["path"])
+        self.obj = _ReconstructedObject(data["modulename"], data["methodname"])
 
 if TYPE_CHECKING:
     from .assertion import SnapshotAssertion
@@ -59,6 +88,8 @@ class SnapshotSession:
     _selected_items: dict[str, ItemStatus] = field(default_factory=dict)
     _assertions: list["SnapshotAssertion"] = field(default_factory=list)
     _extensions: dict[str, "AbstractSyrupyExtension"] = field(default_factory=dict)
+    # Reports published by pytest-xdist workers, collected on the controller.
+    _worker_reports: list[dict[str, Any]] = field(default_factory=list)
 
     _locations_discovered: defaultdict[str, set[Any]] = field(
         default_factory=lambda: defaultdict(set)
@@ -168,6 +199,77 @@ class SnapshotSession:
             except ValueError:
                 pass  # if we don't understand the outcome, leave the item as "not run"
 
+    @staticmethod
+    def _serialize_item(item: "pytest.Item") -> dict[str, str]:
+        obj = item.obj  # type: ignore[attr-defined]
+        return {
+            "nodeid": item.nodeid,
+            "name": item.name,
+            "path": str(item.path),
+            "modulename": obj.__module__,
+            "methodname": obj.__name__,
+        }
+
+    def _publish_worker_report(self) -> None:
+        """Stash this worker's report on ``config.workeroutput`` for the controller."""
+        output = getattr(self.pytest_session.config, "workeroutput", None)
+        if output is None or self.report is None:
+            return
+        payload: dict[str, Any] = {
+            "collections": {
+                name: getattr(self.report, name).serialize()
+                for name in _MERGED_COLLECTIONS
+            },
+            "num_xfails": self.report._num_xfails,
+            "selected": {
+                nodeid: status.value
+                for nodeid, status in self._selected_items.items()
+            },
+            "extensions": {
+                location: (
+                    f"{extension.__class__.__module__}"
+                    f".{extension.__class__.__qualname__}"
+                )
+                for location, extension in self._extensions.items()
+            },
+        }
+        # Every worker collects the identical full set of items, so only one
+        # worker needs to send it to avoid transmitting it once per worker.
+        if os.getenv("PYTEST_XDIST_WORKER") == "gw0":
+            payload["collected"] = [
+                self._serialize_item(item) for item in self._collected_items
+            ]
+        output["syrupy_report"] = payload
+
+    def add_worker_report(self, report: dict[str, Any]) -> None:
+        """Called on the controller for each worker as it shuts down."""
+        self._worker_reports.append(report)
+
+    def _merge_worker_reports(self) -> None:
+        assert self.report is not None
+        selected: dict[str, ItemStatus] = {}
+        for report in self._worker_reports:
+            self.report._num_xfails += report["num_xfails"]
+            for name, serialized in report["collections"].items():
+                getattr(self.report, name).merge_serialized(serialized)
+            for nodeid, value in report["selected"].items():
+                status = ItemStatus(value)
+                # Prefer a concrete run status over NOT_RUN from another worker.
+                if selected.get(nodeid, ItemStatus.NOT_RUN) == ItemStatus.NOT_RUN:
+                    selected[nodeid] = status
+            for location, member in report.get("extensions", {}).items():
+                if location not in self._extensions:
+                    try:
+                        self._extensions[location] = import_module_member(member)()
+                    except FailedToLoadModuleMember:
+                        pass
+            if "collected" in report:
+                self.report.collected_items = {
+                    _ReconstructedItem(item)  # type: ignore[misc]
+                    for item in report["collected"]
+                }
+        self.report.selected_items = selected
+
     def finish(self) -> int:
         exitstatus = 0
         self.flush_snapshot_write_queue()
@@ -180,15 +282,15 @@ class SnapshotSession:
         )
 
         if is_xdist_worker():
-            # TODO: If we're in a pytest-xdist worker, we need to combine the reports
-            #  of all the workers so that the controller can handle unused
-            #  snapshot removal.
+            # Publish this worker's report so the controller can combine the
+            # reports of all workers and handle unused snapshot detection.
+            self._publish_worker_report()
             return exitstatus
-        elif is_xdist_controller():
-            # TODO: If we're in a pytest-xdist controller, merge all the reports.
-            #  Until this is implemented, running syrupy with pytest-xdist is only
-            #  partially functional.
-            return exitstatus
+
+        # On the pytest-xdist controller no tests run locally, so the report is
+        # rebuilt from the reports published by each worker.
+        if self._worker_reports:
+            self._merge_worker_reports()
 
         if self.report.num_unused:
             if self.report.should_delete_unused_snapshots:

--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -57,6 +57,7 @@ class _ReconstructedItem:
         self.path = Path(data["path"])
         self.obj = _ReconstructedObject(data["modulename"], data["methodname"])
 
+
 if TYPE_CHECKING:
     from .assertion import SnapshotAssertion
     from .extensions.base import AbstractSyrupyExtension
@@ -222,8 +223,7 @@ class SnapshotSession:
             },
             "num_xfails": self.report._num_xfails,
             "selected": {
-                nodeid: status.value
-                for nodeid, status in self._selected_items.items()
+                nodeid: status.value for nodeid, status in self._selected_items.items()
             },
             "extensions": {
                 location: (

--- a/src/syrupy/utils.py
+++ b/src/syrupy/utils.py
@@ -23,11 +23,6 @@ def is_xdist_worker() -> bool:
     return bool(worker_name and worker_name != "master")
 
 
-def is_xdist_controller() -> bool:
-    worker_count = os.getenv("PYTEST_XDIST_WORKER_COUNT")
-    return bool(worker_count and int(worker_count) > 0 and not is_xdist_worker())
-
-
 def walk_snapshot_dir(
     root: str | Path, *, ignore_extensions: list[str] | None = None
 ) -> Iterator[str]:

--- a/tests/integration/test_custom_comparator.py
+++ b/tests/integration/test_custom_comparator.py
@@ -80,9 +80,9 @@ def test_failed_snapshots(generate_snapshots):
 
 
 @pytest.mark.xfail(strict=False)
-def test_updated_snapshots(generate_snapshots, plugin_args_fails_xdist):
+def test_updated_snapshots(generate_snapshots, plugin_args):
     _, testdir, initial = generate_snapshots
     testdir.makepyfile(test_file=initial["failed"])
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines((r"1 snapshot updated\.",))
     assert result.ret == 0

--- a/tests/integration/test_overlapping_snapshot_filenames_across_directories.py
+++ b/tests/integration/test_overlapping_snapshot_filenames_across_directories.py
@@ -53,7 +53,7 @@ def overlapping_snapshot_project(pytester: pytest.Pytester) -> pytest.Pytester:
 
 def test_partial_run_does_not_report_unrelated_same_basename_snapshots(
     overlapping_snapshot_project: pytest.Pytester,
-    plugin_args_fails_xdist: list[str],
+    plugin_args: list[str],
 ) -> None:
     """
     Running a subset of tests across modules must not flag snapshots from
@@ -64,7 +64,7 @@ def test_partial_run_does_not_report_unrelated_same_basename_snapshots(
         "--snapshot-details",
         "module_a/tests/test_foo.py",
         "module_b/tests/test_views.py",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines((r"2 snapshots passed\.",))
     result.stdout.no_re_match_line(
@@ -123,7 +123,7 @@ def nested_snapshot_project(pytester: pytest.Pytester) -> pytest.Pytester:
 
 def test_partial_run_does_not_report_unrelated_nested_same_basename_snapshots(
     nested_snapshot_project: pytest.Pytester,
-    plugin_args_fails_xdist: list[str],
+    plugin_args: list[str],
 ) -> None:
     """
     Regression for #918: a nested test file must not cause an unrelated snapshot
@@ -138,7 +138,7 @@ def test_partial_run_does_not_report_unrelated_nested_same_basename_snapshots(
         "--snapshot-details",
         "test_root/components/config/test_config_entries.py",
         "test_root/test_config.py",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines((r"2 snapshots passed\.",))
     result.stdout.no_re_match_line(

--- a/tests/integration/test_pytest_extension.py
+++ b/tests/integration/test_pytest_extension.py
@@ -46,7 +46,7 @@ def test_handles_pyargs_non_module_when_both_given(testdir, plugin_args):
     assert result.ret == 0
 
 
-def test_does_not_print_empty_snapshot_report(testdir, plugin_args_fails_xdist):
+def test_does_not_print_empty_snapshot_report(testdir, plugin_args):
     testdir.makeconftest("")
     testcase_no_snapshots = """
         def test_example(snapshot):
@@ -61,7 +61,7 @@ def test_does_not_print_empty_snapshot_report(testdir, plugin_args_fails_xdist):
     )
 
     result = testdir.runpytest(
-        "-v", "test_file_no.py", "--snapshot-update", *plugin_args_fails_xdist
+        "-v", "test_file_no.py", "--snapshot-update", *plugin_args
     )
     result.stdout.re_match_lines((r".*test_file_no.py.*",))
     assert "snapshot report" not in result.stdout.str()
@@ -69,7 +69,7 @@ def test_does_not_print_empty_snapshot_report(testdir, plugin_args_fails_xdist):
     assert result.ret == 0
 
     result = testdir.runpytest(
-        "-v", "test_file_yes.py", "--snapshot-update", *plugin_args_fails_xdist
+        "-v", "test_file_yes.py", "--snapshot-update", *plugin_args
     )
     result.stdout.re_match_lines((r".*test_file_yes.py.*", r".*snapshot report.*"))
     assert result.ret == 0

--- a/tests/integration/test_single_file_multiple_extensions.py
+++ b/tests/integration/test_single_file_multiple_extensions.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def test_multiple_file_extensions(testdir, plugin_args_fails_xdist):
+def test_multiple_file_extensions(testdir, plugin_args):
     file_extension = "ext2.ext1"
 
     testcase = f"""
@@ -21,7 +21,7 @@ def test_multiple_file_extensions(testdir, plugin_args_fails_xdist):
 
     test_file: Path = testdir.makepyfile(test_file=testcase)
 
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines((r"1 snapshot generated\.",))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
@@ -34,13 +34,13 @@ def test_multiple_file_extensions(testdir, plugin_args_fails_xdist):
     )
     assert snapshot_file.exists()
 
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines((r"1 snapshot passed\.",))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0
 
 
-def test_class_style(testdir, plugin_args_fails_xdist):
+def test_class_style(testdir, plugin_args):
     """
     Regression test for https://github.com/syrupy-project/syrupy/issues/717
     """
@@ -60,7 +60,7 @@ def test_class_style(testdir, plugin_args_fails_xdist):
 
     test_file: Path = testdir.makepyfile(test_file=testcase)
 
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines((r"1 snapshot generated\.",))
     assert "deleted" not in result.stdout.str()
     assert result.ret == 0
@@ -70,7 +70,7 @@ def test_class_style(testdir, plugin_args_fails_xdist):
     )
     assert snapshot_file.exists()
 
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines((r"1 snapshot passed\.",))
     assert "snapshots unused" not in result.stdout.str()
     assert result.ret == 0

--- a/tests/integration/test_snapshot_option_dirname.py
+++ b/tests/integration/test_snapshot_option_dirname.py
@@ -35,10 +35,10 @@ def run_testcases(pytester, testcases) -> tuple[pytest.Pytester, dict[str, str]]
     return pytester, testcases
 
 
-def test_run_all(run_testcases, plugin_args_fails_xdist):
+def test_run_all(run_testcases, plugin_args):
     pytester, _ = run_testcases
     result = pytester.runpytest(
-        "-v", "--snapshot-dirname=snaps", *plugin_args_fails_xdist
+        "-v", "--snapshot-dirname=snaps", *plugin_args
     )
     result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0
@@ -51,11 +51,11 @@ def test_run_all(run_testcases, plugin_args_fails_xdist):
     assert not unexpected_dir.exists()
 
 
-def test_failure(run_testcases, plugin_args_fails_xdist):
+def test_failure(run_testcases, plugin_args):
     pytester, testcases = run_testcases
     pytester.makepyfile(test_1=testcases["modified"])
     result = pytester.runpytest(
-        "-vv", "--snapshot-dirname=snaps", *plugin_args_fails_xdist
+        "-vv", "--snapshot-dirname=snaps", *plugin_args
     )
     result.stdout.re_match_lines(("1 snapshot failed. 1 snapshot passed.",))
     assert result.ret == 1
@@ -68,11 +68,11 @@ def test_failure(run_testcases, plugin_args_fails_xdist):
     assert not unexpected_dir.exists()
 
 
-def test_update(run_testcases, plugin_args_fails_xdist):
+def test_update(run_testcases, plugin_args):
     pytester, testcases = run_testcases
     pytester.makepyfile(test_1=testcases["modified"])
     result = pytester.runpytest(
-        "-v", "--snapshot-dirname=snaps", "--snapshot-update", *plugin_args_fails_xdist
+        "-v", "--snapshot-dirname=snaps", "--snapshot-update", *plugin_args
     )
     assert "Can not relate snapshot name" not in str(result.stdout)
     result.stdout.re_match_lines(("1 snapshot passed. 1 snapshot updated.",))

--- a/tests/integration/test_snapshot_option_dirname.py
+++ b/tests/integration/test_snapshot_option_dirname.py
@@ -37,9 +37,7 @@ def run_testcases(pytester, testcases) -> tuple[pytest.Pytester, dict[str, str]]
 
 def test_run_all(run_testcases, plugin_args):
     pytester, _ = run_testcases
-    result = pytester.runpytest(
-        "-v", "--snapshot-dirname=snaps", *plugin_args
-    )
+    result = pytester.runpytest("-v", "--snapshot-dirname=snaps", *plugin_args)
     result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0
 
@@ -54,9 +52,7 @@ def test_run_all(run_testcases, plugin_args):
 def test_failure(run_testcases, plugin_args):
     pytester, testcases = run_testcases
     pytester.makepyfile(test_1=testcases["modified"])
-    result = pytester.runpytest(
-        "-vv", "--snapshot-dirname=snaps", *plugin_args
-    )
+    result = pytester.runpytest("-vv", "--snapshot-dirname=snaps", *plugin_args)
     result.stdout.re_match_lines(("1 snapshot failed. 1 snapshot passed.",))
     assert result.ret == 1
 

--- a/tests/integration/test_snapshot_option_include_details.py
+++ b/tests/integration/test_snapshot_option_include_details.py
@@ -68,12 +68,12 @@ def test_unused_snapshots_details(
     expected_status_code,
     run_testfiles_with_update,
     testcases,
-    plugin_args_fails_xdist,
+    plugin_args,
 ):
     testdir = run_testfiles_with_update(test_file=testcases)
     testdir.makepyfile(test_file=testcases["used"])
 
-    result = testdir.runpytest(*options, *plugin_args_fails_xdist)
+    result = testdir.runpytest(*options, *plugin_args)
     result.stdout.re_match_lines(
         (
             r"1 snapshot passed\. 1 snapshot unused\.",
@@ -85,7 +85,7 @@ def test_unused_snapshots_details(
 
 
 def test_unused_snapshots_details_multiple_tests(
-    run_testfiles_with_update, testcases, extra_testcases, plugin_args_fails_xdist
+    run_testfiles_with_update, testcases, extra_testcases, plugin_args
 ):
     testdir = run_testfiles_with_update(
         test_file=testcases, test_second_file=extra_testcases
@@ -95,7 +95,7 @@ def test_unused_snapshots_details_multiple_tests(
         test_second_file="",
     )
 
-    result = testdir.runpytest("-v", "--snapshot-details", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-details", *plugin_args)
     result.stdout.re_match_lines(
         (
             r"2 snapshots passed\. 2 snapshots unused\.",
@@ -108,7 +108,7 @@ def test_unused_snapshots_details_multiple_tests(
 
 
 def test_unused_snapshots_details_multiple_locations(
-    run_testfiles_with_update, testcases, extra_testcases, plugin_args_fails_xdist
+    run_testfiles_with_update, testcases, extra_testcases, plugin_args
 ):
     testdir = run_testfiles_with_update(
         test_file=testcases, test_second_file=extra_testcases
@@ -118,7 +118,7 @@ def test_unused_snapshots_details_multiple_locations(
         test_second_file=extra_testcases["extra_a"],
     )
 
-    result = testdir.runpytest("-v", "--snapshot-details", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-details", *plugin_args)
     result.stdout.re_match_lines_random(
         (
             r"2 snapshots passed\. 2 snapshots unused\.",
@@ -131,13 +131,13 @@ def test_unused_snapshots_details_multiple_locations(
 
 
 def test_unused_snapshots_details_no_details_on_deletion(
-    run_testfiles_with_update, testcases, plugin_args_fails_xdist
+    run_testfiles_with_update, testcases, plugin_args
 ):
     testdir = run_testfiles_with_update(test_file=testcases)
     testdir.makepyfile(test_file=testcases["used"])
 
     result = testdir.runpytest(
-        "-v", "--snapshot-details", "--snapshot-update", *plugin_args_fails_xdist
+        "-v", "--snapshot-details", "--snapshot-update", *plugin_args
     )
     result.stdout.re_match_lines(
         (
@@ -148,7 +148,7 @@ def test_unused_snapshots_details_no_details_on_deletion(
     assert result.ret == 0
 
 
-def test_created_and_updates_details(testdir, plugin_args_fails_xdist):
+def test_created_and_updates_details(testdir, plugin_args):
     # Generate initial snapshots.
     testdir.makepyfile(
         test_generated="""
@@ -177,7 +177,7 @@ def test_created_and_updates_details(testdir, plugin_args_fails_xdist):
     )
 
     result = testdir.runpytest(
-        "-v", "--snapshot-details", "--snapshot-update", *plugin_args_fails_xdist
+        "-v", "--snapshot-details", "--snapshot-update", *plugin_args
     )
     result.stdout.re_match_lines(
         (

--- a/tests/integration/test_snapshot_option_name.py
+++ b/tests/integration/test_snapshot_option_name.py
@@ -32,25 +32,25 @@ def run_testcases(testdir, testcases):
     return testdir, testcases
 
 
-def test_run_all(run_testcases, plugin_args_fails_xdist):
+def test_run_all(run_testcases, plugin_args):
     testdir, testcases = run_testcases
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0
 
 
-def test_failure(run_testcases, plugin_args_fails_xdist):
+def test_failure(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     testdir.makepyfile(test_1=testcases["modified"])
-    result = testdir.runpytest("-vv", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-vv", *plugin_args)
     result.stdout.re_match_lines(("1 snapshot failed. 1 snapshot passed.",))
     assert result.ret == 1
 
 
-def test_update(run_testcases, plugin_args_fails_xdist):
+def test_update(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     testdir.makepyfile(test_1=testcases["modified"])
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     assert "Can not relate snapshot name" not in str(result.stdout)
     result.stdout.re_match_lines(("1 snapshot passed. 1 snapshot updated.",))
     assert result.ret == 0

--- a/tests/integration/test_snapshot_option_update.py
+++ b/tests/integration/test_snapshot_option_update.py
@@ -184,17 +184,17 @@ def test_update_failure_shows_snapshot_diff(
 
 
 def test_update_success_shows_snapshot_report(
-    run_testcases, testcases_updated, plugin_args_fails_xdist
+    run_testcases, testcases_updated, plugin_args
 ):
     testdir = run_testcases[1]
     testdir.makepyfile(**testcases_updated)
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines((r"5 snapshots passed\. 5 snapshots updated\.",))
     assert result.ret == 0
 
 
 def test_update_targets_only_selected_parametrized_tests_for_update_dash_m(
-    run_testcases, plugin_args_fails_xdist
+    run_testcases, plugin_args
 ):
     updated_tests = {
         "test_used": (
@@ -210,7 +210,7 @@ def test_update_targets_only_selected_parametrized_tests_for_update_dash_m(
     testdir = run_testcases[1]
     testdir.makepyfile(**updated_tests)
     result = testdir.runpytest(
-        "-v", "--snapshot-update", *plugin_args_fails_xdist, "-m", "parametrize"
+        "-v", "--snapshot-update", *plugin_args, "-m", "parametrize"
     )
     result.stdout.re_match_lines(
         (
@@ -224,7 +224,7 @@ def test_update_targets_only_selected_parametrized_tests_for_update_dash_m(
 
 
 def test_update_targets_only_selected_parametrized_tests_for_update_dash_k(
-    run_testcases, plugin_args_fails_xdist
+    run_testcases, plugin_args
 ):
     updated_tests = {
         "test_used": (
@@ -240,7 +240,7 @@ def test_update_targets_only_selected_parametrized_tests_for_update_dash_k(
     testdir = run_testcases[1]
     testdir.makepyfile(**updated_tests)
     result = testdir.runpytest(
-        "-v", "--snapshot-update", *plugin_args_fails_xdist, "-k", "test_used[2]"
+        "-v", "--snapshot-update", *plugin_args, "-k", "test_used[2]"
     )
     result.stdout.re_match_lines((r"1 snapshot updated\.",))
     assert "Deleted" not in result.stdout.str()
@@ -250,7 +250,7 @@ def test_update_targets_only_selected_parametrized_tests_for_update_dash_k(
 
 
 def test_update_targets_only_selected_parametrized_tests_for_removal_dash_k(
-    run_testcases, plugin_args_fails_xdist
+    run_testcases, plugin_args
 ):
     updated_tests = {
         "test_used": (
@@ -266,7 +266,7 @@ def test_update_targets_only_selected_parametrized_tests_for_removal_dash_k(
     testdir = run_testcases[1]
     testdir.makepyfile(**updated_tests)
     result = testdir.runpytest(
-        "-v", "--snapshot-update", *plugin_args_fails_xdist, "-k", "test_used["
+        "-v", "--snapshot-update", *plugin_args, "-k", "test_used["
     )
     result.stdout.re_match_lines(
         (
@@ -280,7 +280,7 @@ def test_update_targets_only_selected_parametrized_tests_for_removal_dash_k(
 
 
 def test_update_no_cleanup_keeps_unused_snapshots(
-    run_testcases, plugin_args_fails_xdist
+    run_testcases, plugin_args
 ):
     updated_tests = {
         "test_used": (
@@ -299,7 +299,7 @@ def test_update_no_cleanup_keeps_unused_snapshots(
         "-v",
         "--snapshot-update",
         "--snapshot-no-cleanup",
-        *plugin_args_fails_xdist,
+        *plugin_args,
         "-k",
         "test_used[",
     )
@@ -313,7 +313,7 @@ def test_update_no_cleanup_keeps_unused_snapshots(
 
 
 def test_update_targets_only_selected_class_tests_dash_k(
-    testdir, plugin_args_fails_xdist
+    testdir, plugin_args
 ):
     test_content = """
         import pytest
@@ -331,14 +331,14 @@ def test_update_targets_only_selected_class_tests_dash_k(
     assert Path(testdir.tmpdir, "__snapshots__", "test_content.ambr").exists()
 
     result = testdir.runpytest(
-        "test_content.py", "-v", *plugin_args_fails_xdist, "-k", "test_case_2"
+        "test_content.py", "-v", *plugin_args, "-k", "test_case_2"
     )
     result.stdout.re_match_lines((r"1 snapshot passed\.",))
     assert "snapshot unused" not in result.stdout.str()
 
 
 def test_update_targets_only_selected_module_tests_dash_k(
-    testdir, plugin_args_fails_xdist
+    testdir, plugin_args
 ):
     test_content = """
         import pytest
@@ -355,21 +355,21 @@ def test_update_targets_only_selected_module_tests_dash_k(
     assert Path(testdir.tmpdir, "__snapshots__", "test_content.ambr").exists()
 
     result = testdir.runpytest(
-        "test_content.py", "-v", *plugin_args_fails_xdist, "-k", "test_case_2"
+        "test_content.py", "-v", *plugin_args, "-k", "test_case_2"
     )
     result.stdout.re_match_lines((r"1 snapshot passed\.",))
     assert "snapshot unused" not in result.stdout.str()
 
 
 def test_update_targets_only_selected_module_tests_nodes(
-    run_testcases, plugin_args_fails_xdist
+    run_testcases, plugin_args
 ):
     testdir = run_testcases[1]
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
     testfile = Path(testdir.tmpdir, "test_used.py")
     result = testdir.runpytest(
-        "-v", f"{testfile}::test_used", "--snapshot-update", *plugin_args_fails_xdist
+        "-v", f"{testfile}::test_used", "--snapshot-update", *plugin_args
     )
     result.stdout.re_match_lines((r"3 snapshots passed\.",))
     assert "unused" not in result.stdout.str()
@@ -401,7 +401,7 @@ def test_update_targets_only_selected_module_tests_nodes_pyargs(
 
 
 def test_update_targets_only_selected_module_tests_file_for_update(
-    run_testcases, plugin_args_fails_xdist
+    run_testcases, plugin_args
 ):
     testdir = run_testcases[1]
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
@@ -418,7 +418,7 @@ def test_update_targets_only_selected_module_tests_file_for_update(
         )
     )
     result = testdir.runpytest(
-        "-v", "test_used.py", "--snapshot-update", *plugin_args_fails_xdist
+        "-v", "test_used.py", "--snapshot-update", *plugin_args
     )
     result.stdout.re_match_lines(
         (
@@ -432,7 +432,7 @@ def test_update_targets_only_selected_module_tests_file_for_update(
 
 
 def test_update_targets_only_selected_module_tests_file_for_removal(
-    run_testcases, plugin_args_fails_xdist
+    run_testcases, plugin_args
 ):
     testdir = run_testcases[1]
     testdir.makepyfile(
@@ -446,7 +446,7 @@ def test_update_targets_only_selected_module_tests_file_for_removal(
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
     result = testdir.runpytest(
-        "-v", "test_used.py", "--snapshot-update", *plugin_args_fails_xdist
+        "-v", "test_used.py", "--snapshot-update", *plugin_args
     )
     result.stdout.re_match_lines(
         (
@@ -461,13 +461,13 @@ def test_update_targets_only_selected_module_tests_file_for_removal(
 
 
 def test_update_removes_empty_snapshot_collection_only(
-    run_testcases, plugin_args_fails_xdist
+    run_testcases, plugin_args
 ):
     testdir = run_testcases[1]
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
     assert snapfile_empty.exists()
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(
         (
             r"10 snapshots passed\. 1 unused snapshot deleted\.",
@@ -481,14 +481,14 @@ def test_update_removes_empty_snapshot_collection_only(
 
 
 def test_update_removes_hanging_snapshot_collection_file(
-    run_testcases, plugin_args_fails_xdist
+    run_testcases, plugin_args
 ):
     testdir = run_testcases[1]
     snapfile_used = Path("__snapshots__", "test_used.ambr")
     snapfile_hanging = Path("__snapshots__", "hanging_snapfile.abc")
     testdir.makefile(".abc", **{str(snapfile_hanging): ""})
     assert snapfile_hanging.exists()
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(
         (
             r"10 snapshots passed\. 1 unused snapshot deleted\.",

--- a/tests/integration/test_snapshot_option_update.py
+++ b/tests/integration/test_snapshot_option_update.py
@@ -279,9 +279,7 @@ def test_update_targets_only_selected_parametrized_tests_for_removal_dash_k(
     assert Path(*snapshot_path, "test_updated_1.ambr").exists()
 
 
-def test_update_no_cleanup_keeps_unused_snapshots(
-    run_testcases, plugin_args
-):
+def test_update_no_cleanup_keeps_unused_snapshots(run_testcases, plugin_args):
     updated_tests = {
         "test_used": (
             """
@@ -312,9 +310,7 @@ def test_update_no_cleanup_keeps_unused_snapshots(
     assert "test_used[3]" in snapshot_file.read_text()
 
 
-def test_update_targets_only_selected_class_tests_dash_k(
-    testdir, plugin_args
-):
+def test_update_targets_only_selected_class_tests_dash_k(testdir, plugin_args):
     test_content = """
         import pytest
 
@@ -337,9 +333,7 @@ def test_update_targets_only_selected_class_tests_dash_k(
     assert "snapshot unused" not in result.stdout.str()
 
 
-def test_update_targets_only_selected_module_tests_dash_k(
-    testdir, plugin_args
-):
+def test_update_targets_only_selected_module_tests_dash_k(testdir, plugin_args):
     test_content = """
         import pytest
 
@@ -361,9 +355,7 @@ def test_update_targets_only_selected_module_tests_dash_k(
     assert "snapshot unused" not in result.stdout.str()
 
 
-def test_update_targets_only_selected_module_tests_nodes(
-    run_testcases, plugin_args
-):
+def test_update_targets_only_selected_module_tests_nodes(run_testcases, plugin_args):
     testdir = run_testcases[1]
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
@@ -417,9 +409,7 @@ def test_update_targets_only_selected_module_tests_file_for_update(
             """
         )
     )
-    result = testdir.runpytest(
-        "-v", "test_used.py", "--snapshot-update", *plugin_args
-    )
+    result = testdir.runpytest("-v", "test_used.py", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(
         (
             r"3 snapshots passed\. 2 unused snapshots deleted\.",
@@ -445,9 +435,7 @@ def test_update_targets_only_selected_module_tests_file_for_removal(
     )
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
-    result = testdir.runpytest(
-        "-v", "test_used.py", "--snapshot-update", *plugin_args
-    )
+    result = testdir.runpytest("-v", "test_used.py", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(
         (
             r"5 unused snapshots deleted\.",
@@ -460,9 +448,7 @@ def test_update_targets_only_selected_module_tests_file_for_removal(
     assert not Path("__snapshots__", "test_used.ambr").exists()
 
 
-def test_update_removes_empty_snapshot_collection_only(
-    run_testcases, plugin_args
-):
+def test_update_removes_empty_snapshot_collection_only(run_testcases, plugin_args):
     testdir = run_testcases[1]
     snapfile_empty = Path("__snapshots__", "empty_snapfile.ambr")
     testdir.makefile(".ambr", **{str(snapfile_empty): ""})
@@ -480,9 +466,7 @@ def test_update_removes_empty_snapshot_collection_only(
     assert Path("__snapshots__", "test_used.ambr").exists()
 
 
-def test_update_removes_hanging_snapshot_collection_file(
-    run_testcases, plugin_args
-):
+def test_update_removes_hanging_snapshot_collection_file(run_testcases, plugin_args):
     testdir = run_testcases[1]
     snapfile_used = Path("__snapshots__", "test_used.ambr")
     snapfile_hanging = Path("__snapshots__", "hanging_snapfile.abc")

--- a/tests/integration/test_snapshot_option_warn_unused.py
+++ b/tests/integration/test_snapshot_option_warn_unused.py
@@ -28,11 +28,11 @@ def run_testcases(testdir, testcases):
     return testdir, testcases
 
 
-def test_unused_snapshots_failure(run_testcases, plugin_args_fails_xdist):
+def test_unused_snapshots_failure(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     testdir.makepyfile(test_file=testcases["used"])
 
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines(
         (
             r"1 snapshot passed\. 1 snapshot unused\.",
@@ -42,11 +42,11 @@ def test_unused_snapshots_failure(run_testcases, plugin_args_fails_xdist):
     assert result.ret == 1
 
 
-def test_unused_snapshots_warning(run_testcases, plugin_args_fails_xdist):
+def test_unused_snapshots_warning(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     testdir.makepyfile(test_file=testcases["used"])
 
-    result = testdir.runpytest("-v", "--snapshot-warn-unused", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-warn-unused", *plugin_args)
     result.stdout.re_match_lines(
         (
             r"1 snapshot passed\. 1 snapshot unused\.",
@@ -56,11 +56,11 @@ def test_unused_snapshots_warning(run_testcases, plugin_args_fails_xdist):
     assert result.ret == 0
 
 
-def test_unused_snapshots_deletion(run_testcases, plugin_args_fails_xdist):
+def test_unused_snapshots_deletion(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     testdir.makepyfile(test_file=testcases["used"])
 
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(
         (
             r"1 snapshot passed\. 1 unused snapshot deleted\.",

--- a/tests/integration/test_snapshot_outside_directory.py
+++ b/tests/integration/test_snapshot_outside_directory.py
@@ -57,25 +57,25 @@ def test_generated_snapshots(generate_snapshots):
     assert result.ret == 0
 
 
-def test_unmatched_snapshots(generate_snapshots, plugin_args_fails_xdist):
+def test_unmatched_snapshots(generate_snapshots, plugin_args):
     _, testdir, testcases = generate_snapshots
     testdir.makepyfile(test_file=testcases["one"])
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines((r"1 snapshot passed. 1 snapshot unused\.",))
     assert result.ret == 1
 
 
-def test_updated_snapshots_partial_delete(generate_snapshots, plugin_args_fails_xdist):
+def test_updated_snapshots_partial_delete(generate_snapshots, plugin_args):
     _, testdir, testcases = generate_snapshots
     testdir.makepyfile(test_file=testcases["one"])
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(r"1 snapshot passed. 1 unused snapshot deleted\.")
     assert result.ret == 0
 
 
-def test_updated_snapshots_full_delete(generate_snapshots, plugin_args_fails_xdist):
+def test_updated_snapshots_full_delete(generate_snapshots, plugin_args):
     _, testdir, testcases = generate_snapshots
     testdir.makepyfile(test_file=testcases["zero"])
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(r"2 unused snapshots deleted\.")
     assert result.ret == 0

--- a/tests/integration/test_snapshot_similar_names_default.py
+++ b/tests/integration/test_snapshot_similar_names_default.py
@@ -36,61 +36,61 @@ def run_testcases(testdir, testcases):
     return testdir, testcases
 
 
-def test_run_all(run_testcases, plugin_args_fails_xdist):
+def test_run_all(run_testcases, plugin_args):
     testdir, testcases = run_testcases
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines(("9 snapshots passed",))
     assert result.ret == 0
 
 
-def test_run_single_file(run_testcases, plugin_args_fails_xdist):
+def test_run_single_file(run_testcases, plugin_args):
     testdir, testcases = run_testcases
-    result = testdir.runpytest("-v", "test_1.py", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "test_1.py", *plugin_args)
     result.stdout.re_match_lines(("3 snapshots passed",))
     assert result.ret == 0
 
 
-def test_run_single_test_case_in_file(run_testcases, plugin_args_fails_xdist):
+def test_run_single_test_case_in_file(run_testcases, plugin_args):
     testdir, testcases = run_testcases
-    result = testdir.runpytest("-v", "test_2.py::test_a", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "test_2.py::test_a", *plugin_args)
     result.stdout.re_match_lines(("1 snapshot passed",))
     assert result.ret == 0
 
 
-def test_run_all_but_one(run_testcases, plugin_args_fails_xdist):
+def test_run_all_but_one(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     result = testdir.runpytest(
         "-v",
         "--snapshot-details",
         "test_1.py",
         "test_2.py::test_a",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines(("4 snapshots passed",))
     assert result.ret == 0
 
 
-def test_run_both_files_by_node(run_testcases, plugin_args_fails_xdist):
+def test_run_both_files_by_node(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     result = testdir.runpytest(
         "-v",
         "--snapshot-details",
         "test_1.py::test_a",
         "test_2.py::test_a",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0
 
 
-def test_run_both_files_by_node_2(run_testcases, plugin_args_fails_xdist):
+def test_run_both_files_by_node_2(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     result = testdir.runpytest(
         "-v",
         "--snapshot-details",
         "test_1.py::test_b",
         "test_2.py::test_a",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0

--- a/tests/integration/test_snapshot_similar_names_file_extension.py
+++ b/tests/integration/test_snapshot_similar_names_file_extension.py
@@ -41,45 +41,45 @@ def run_testcases(testdir, testcases):
     return testdir, testcases
 
 
-def test_run_all(run_testcases, plugin_args_fails_xdist):
+def test_run_all(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     result = testdir.runpytest(
         "-v",
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines(("9 snapshots passed",))
     assert result.ret == 0
 
 
-def test_run_single_file(run_testcases, plugin_args_fails_xdist):
+def test_run_single_file(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     result = testdir.runpytest(
         "-v",
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
         "test_1.py",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines(("3 snapshots passed",))
     assert result.ret == 0
 
 
-def test_run_single_test_case_in_file(run_testcases, plugin_args_fails_xdist):
+def test_run_single_test_case_in_file(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     result = testdir.runpytest(
         "-v",
         "--snapshot-default-extension",
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
         "test_2.py::test_a",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines(("1 snapshot passed",))
     assert result.ret == 0
 
 
-def test_run_all_but_one(run_testcases, plugin_args_fails_xdist):
+def test_run_all_but_one(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     result = testdir.runpytest(
         "-v",
@@ -88,13 +88,13 @@ def test_run_all_but_one(run_testcases, plugin_args_fails_xdist):
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
         "test_1.py",
         "test_2.py::test_a",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines(("4 snapshots passed",))
     assert result.ret == 0
 
 
-def test_run_both_files_by_node(run_testcases, plugin_args_fails_xdist):
+def test_run_both_files_by_node(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     result = testdir.runpytest(
         "-v",
@@ -103,13 +103,13 @@ def test_run_both_files_by_node(run_testcases, plugin_args_fails_xdist):
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
         "test_1.py::test_a",
         "test_2.py::test_a",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0
 
 
-def test_run_both_files_by_node_2(run_testcases, plugin_args_fails_xdist):
+def test_run_both_files_by_node_2(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     result = testdir.runpytest(
         "-v",
@@ -118,7 +118,7 @@ def test_run_both_files_by_node_2(run_testcases, plugin_args_fails_xdist):
         "syrupy.extensions.single_file.SingleFileSnapshotExtension",
         "test_1.py::test_b",
         "test_2.py::test_a",
-        *plugin_args_fails_xdist,
+        *plugin_args,
     )
     result.stdout.re_match_lines(("2 snapshots passed",))
     assert result.ret == 0

--- a/tests/integration/test_snapshot_skipped.py
+++ b/tests/integration/test_snapshot_skipped.py
@@ -44,31 +44,31 @@ def run_testcases(testdir, testcases):
     return testdir, testcases
 
 
-def test_mark_skipped_snapshots(run_testcases, plugin_args_fails_xdist):
+def test_mark_skipped_snapshots(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     pyfile_content = "\n\n".join([testcases["used"], testcases["mark-skipped"]])
     testdir.makepyfile(test_file=pyfile_content)
 
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines(r"1 snapshot passed\.$")
     assert result.ret == 0
 
 
-def test_raise_skipped_snapshots(run_testcases, plugin_args_fails_xdist):
+def test_raise_skipped_snapshots(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     pyfile_content = "\n\n".join([testcases["used"], testcases["raise-skipped"]])
     testdir.makepyfile(test_file=pyfile_content)
 
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines(r"1 snapshot passed\.$")
     assert result.ret == 0
 
 
-def test_skipped_snapshots_update(run_testcases, plugin_args_fails_xdist):
+def test_skipped_snapshots_update(run_testcases, plugin_args):
     testdir, testcases = run_testcases
     pyfile_content = "\n\n".join([testcases["used"], testcases["raise-skipped"]])
     testdir.makepyfile(test_file=pyfile_content)
 
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(r"1 snapshot passed\.$")
     assert result.ret == 0

--- a/tests/integration/test_snapshot_use_extension.py
+++ b/tests/integration/test_snapshot_use_extension.py
@@ -118,9 +118,7 @@ def test_generated_snapshots(generate_snapshots):
     assert result.ret == 0
 
 
-def test_unmatched_snapshots(
-    generate_snapshots, testcases_updated, plugin_args
-):
+def test_unmatched_snapshots(generate_snapshots, testcases_updated, plugin_args):
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=testcases_updated["passed"])
     result = testdir.runpytest("-v", *plugin_args)
@@ -128,9 +126,7 @@ def test_unmatched_snapshots(
     assert result.ret == 1
 
 
-def test_updated_snapshots(
-    generate_snapshots, testcases_updated, plugin_args
-):
+def test_updated_snapshots(generate_snapshots, testcases_updated, plugin_args):
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=testcases_updated["passed"])
     result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)

--- a/tests/integration/test_snapshot_use_extension.py
+++ b/tests/integration/test_snapshot_use_extension.py
@@ -104,9 +104,9 @@ def test_unsaved_snapshots(testdir, testcases_initial):
     assert result.ret == 1
 
 
-def test_failed_snapshots(testdir, testcases_initial, plugin_args_fails_xdist):
+def test_failed_snapshots(testdir, testcases_initial, plugin_args):
     testdir.makepyfile(test_file=testcases_initial["failed"])
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines((r"2 snapshots failed\.",))
     assert result.ret == 1
 
@@ -119,21 +119,21 @@ def test_generated_snapshots(generate_snapshots):
 
 
 def test_unmatched_snapshots(
-    generate_snapshots, testcases_updated, plugin_args_fails_xdist
+    generate_snapshots, testcases_updated, plugin_args
 ):
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=testcases_updated["passed"])
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines((r"1 snapshot failed\. 2 snapshots unused\.",))
     assert result.ret == 1
 
 
 def test_updated_snapshots(
-    generate_snapshots, testcases_updated, plugin_args_fails_xdist
+    generate_snapshots, testcases_updated, plugin_args
 ):
     testdir = generate_snapshots[1]
     testdir.makepyfile(test_file=testcases_updated["passed"])
-    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(
         (r"1 snapshot updated\. 2 unused snapshots deleted\.",)
     )

--- a/tests/integration/test_snapshot_xdist.py
+++ b/tests/integration/test_snapshot_xdist.py
@@ -1,0 +1,56 @@
+"""Unused snapshot detection and removal across pytest-xdist workers.
+
+See https://github.com/syrupy-project/syrupy/issues/535: each worker reports
+the snapshots it used and the controller combines them, so unused snapshots are
+detected even when the tests that own them ran on a different worker.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def _write(testdir, params: str) -> None:
+    for name in ("test_a", "test_b"):
+        Path(testdir.tmpdir, f"{name}.py").write_text(
+            "import pytest\n\n"
+            f"@pytest.mark.parametrize('i', {params})\n"
+            f"def {name}(i, snapshot):\n"
+            "    assert i == snapshot\n"
+        )
+
+
+@pytest.fixture
+def generated(testdir):
+    _write(testdir, "[0, 1, 2, 3]")
+    result = testdir.runpytest("-v", "--snapshot-update")
+    result.stdout.re_match_lines((r"8 snapshots generated\.",))
+    return testdir
+
+
+def test_xdist_detects_unused(generated):
+    testdir = generated
+    # Drop two parametrizations per file, leaving 4 snapshots unused.
+    _write(testdir, "[0, 1]")
+
+    result = testdir.runpytest("-v", "--numprocesses", "2")
+
+    result.stdout.re_match_lines((r".*4 snapshots unused\.",))
+    assert result.ret != 0
+
+
+def test_xdist_removes_unused(generated):
+    testdir = generated
+    _write(testdir, "[0, 1]")
+
+    result = testdir.runpytest("-v", "--numprocesses", "2", "--snapshot-update")
+
+    result.stdout.re_match_lines((r".*4 unused snapshots deleted\.",))
+    assert result.ret == 0
+
+    # Partial removal within each shared file: used snapshots are kept.
+    content = Path(testdir.tmpdir, "__snapshots__", "test_a.ambr").read_text()
+    assert "test_a[0]" in content
+    assert "test_a[1]" in content
+    assert "test_a[2]" not in content
+    assert "test_a[3]" not in content

--- a/tests/integration/test_xfail.py
+++ b/tests/integration/test_xfail.py
@@ -15,9 +15,7 @@ def test_no_failure_printed_if_all_failures_xfailed(testdir, plugin_args):
     assert result.ret == 0
 
 
-def test_failures_printed_if_only_some_failures_xfailed(
-    testdir, plugin_args
-):
+def test_failures_printed_if_only_some_failures_xfailed(testdir, plugin_args):
     testdir.makepyfile(
         test_file=(
             """

--- a/tests/integration/test_xfail.py
+++ b/tests/integration/test_xfail.py
@@ -16,7 +16,7 @@ def test_no_failure_printed_if_all_failures_xfailed(testdir, plugin_args):
 
 
 def test_failures_printed_if_only_some_failures_xfailed(
-    testdir, plugin_args_fails_xdist
+    testdir, plugin_args
 ):
     testdir.makepyfile(
         test_file=(
@@ -32,13 +32,13 @@ def test_failures_printed_if_only_some_failures_xfailed(
         """
         )
     )
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines((r".*1 snapshot failed*",))
     result.stdout.re_match_lines((r".*1 snapshot xfailed*",))
     assert result.ret == 1
 
 
-def test_failure_printed_if_xfail_does_not_run(testdir, plugin_args_fails_xdist):
+def test_failure_printed_if_xfail_does_not_run(testdir, plugin_args):
     testdir.makepyfile(
         test_file=(
             """
@@ -50,7 +50,7 @@ def test_failure_printed_if_xfail_does_not_run(testdir, plugin_args_fails_xdist)
         """
         )
     )
-    result = testdir.runpytest("-v", *plugin_args_fails_xdist)
+    result = testdir.runpytest("-v", *plugin_args)
     result.stdout.re_match_lines((r".*1 snapshot failed*",))
     result.stdout.no_re_match_line(r".*1 snapshot xfailed*")
     assert result.ret == 1

--- a/tests/syrupy/test_session_xdist.py
+++ b/tests/syrupy/test_session_xdist.py
@@ -1,0 +1,189 @@
+"""Unit tests for the pytest-xdist worker/controller report merging."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from syrupy.data import Snapshot, SnapshotCollection
+from syrupy.extensions.amber import AmberSnapshotExtension
+from syrupy.report import SnapshotReport
+from syrupy.session import ItemStatus, SnapshotSession
+
+LOCATION = str(Path("/tmp", "__snapshots__", "test_a.ambr"))
+
+
+def _options() -> SimpleNamespace:
+    return SimpleNamespace(keyword="", file_or_dir=[], pyargs=False)
+
+
+def _session(workeroutput: dict | None = None) -> SnapshotSession:
+    config = SimpleNamespace(option=_options(), rootpath=Path("/tmp"))
+    if workeroutput is not None:
+        config.workeroutput = workeroutput
+    session = SnapshotSession(pytest_session=SimpleNamespace(config=config))
+    session.report = SnapshotReport(
+        base_dir=Path("/tmp"),
+        collected_items=set(),
+        selected_items={},
+        options=config.option,
+        assertions=[],
+    )
+    return session
+
+
+def _collection(*names: str) -> SnapshotCollection:
+    collection = SnapshotCollection(location=LOCATION)
+    for name in names:
+        collection.add(Snapshot(name=name))
+    return collection
+
+
+def test_collection_serialize_roundtrip():
+    collection = SnapshotCollection(location=LOCATION)
+    collection.add(Snapshot(name="test_a"))
+    collection.add(Snapshot(name="test_b"))
+
+    from syrupy.data import SnapshotCollections
+
+    collections = SnapshotCollections()
+    collections.add(collection)
+
+    restored = SnapshotCollections()
+    restored.merge_serialized(collections.serialize())
+
+    assert restored.serialize() == {LOCATION: ["test_a", "test_b"]}
+
+
+def test_worker_publishes_minimal_report(monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    worker = _session(workeroutput={})
+    worker.report.used.update(_collection("test_a"))
+    worker.report.discovered.update(_collection("test_a", "test_b"))
+    worker.report._num_xfails = 2
+    worker._selected_items = {"test_a.py::test_a": ItemStatus.PASSED}
+    worker._extensions = {LOCATION: AmberSnapshotExtension()}
+
+    class _Obj:
+        __module__ = "test_a"
+        __name__ = "test_a"
+
+    class _Item:
+        nodeid = "test_a.py::test_a"
+        name = "test_a"
+        path = Path("/tmp/test_a.py")
+        obj = _Obj()
+
+    worker._collected_items = {_Item()}
+
+    worker._publish_worker_report()
+
+    payload = worker.pytest_session.config.workeroutput["syrupy_report"]
+    assert payload["collections"]["used"] == {LOCATION: ["test_a"]}
+    assert payload["num_xfails"] == 2
+    assert payload["selected"] == {"test_a.py::test_a": "passed"}
+    assert payload["extensions"] == {
+        LOCATION: "syrupy.extensions.amber.AmberSnapshotExtension"
+    }
+    # gw0 is the only worker that ships the collected items.
+    assert payload["collected"][0]["nodeid"] == "test_a.py::test_a"
+
+
+def test_worker_without_workeroutput_is_noop():
+    # A non-xdist session has no workeroutput; publishing must be safe.
+    worker = _session()
+    worker._publish_worker_report()  # should not raise
+
+
+def test_non_gw0_worker_omits_collected(monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw1")
+    worker = _session(workeroutput={})
+    worker._publish_worker_report()
+    assert "collected" not in worker.pytest_session.config.workeroutput["syrupy_report"]
+
+
+def test_controller_merges_worker_reports():
+    controller = _session()
+    controller.add_worker_report(
+        {
+            "collections": {
+                "discovered": {LOCATION: ["test_a", "test_b"]},
+                "created": {},
+                "failed": {},
+                "matched": {LOCATION: ["test_a"]},
+                "updated": {},
+                "used": {LOCATION: ["test_a"]},
+            },
+            "num_xfails": 1,
+            "selected": {"test_a.py::test_a": "passed"},
+            "extensions": {LOCATION: "syrupy.extensions.amber.AmberSnapshotExtension"},
+            "collected": [
+                {
+                    "nodeid": "test_a.py::test_a",
+                    "name": "test_a",
+                    "path": "/tmp/test_a.py",
+                    "modulename": "test_a",
+                    "methodname": "test_a",
+                }
+            ],
+        }
+    )
+    controller.add_worker_report(
+        {
+            "collections": {
+                "discovered": {},
+                "created": {},
+                "failed": {},
+                "matched": {},
+                "updated": {},
+                "used": {},
+            },
+            "num_xfails": 2,
+            "selected": {"test_a.py::test_a": False},
+            "extensions": {},
+        }
+    )
+
+    controller._merge_worker_reports()
+
+    report = controller.report
+    assert report.used.serialize() == {LOCATION: ["test_a"]}
+    assert report.discovered.serialize() == {LOCATION: ["test_a", "test_b"]}
+    # xfail counts accumulate across workers.
+    assert report._num_xfails == 3
+    # The concrete PASSED status wins over NOT_RUN from the other worker.
+    assert report.selected_items["test_a.py::test_a"] == ItemStatus.PASSED
+    # Extension reconstructed for partial removal.
+    assert isinstance(controller._extensions[LOCATION], AmberSnapshotExtension)
+    # Collected item reconstructed for location matching.
+    item = next(iter(report.collected_items))
+    assert item.nodeid == "test_a.py::test_a"
+    assert item.obj.__module__ == "test_a"
+
+
+def test_controller_ignores_unimportable_extension():
+    controller = _session()
+    controller.add_worker_report(
+        {
+            "collections": {
+                name: {}
+                for name in (
+                    "discovered",
+                    "created",
+                    "failed",
+                    "matched",
+                    "updated",
+                    "used",
+                )
+            },
+            "num_xfails": 0,
+            "selected": {},
+            "extensions": {LOCATION: "does.not.Exist"},
+        }
+    )
+    controller._merge_worker_reports()
+    assert LOCATION not in controller._extensions
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__])


### PR DESCRIPTION
## Description

Running with `pytest-xdist` (`-n`) disabled unused snapshot detection: each worker only sees the tests it ran, so it can't tell whether a snapshot is unused or just owned by a test that ran on another worker. As a result `--snapshot-update` under xdist never removed obsolete snapshots, and plain runs never failed on them.

This makes it work. Each worker publishes the snapshots it touched on `config.workeroutput`; the controller harvests them in `pytest_testnodedown` and combines them, then runs the existing unused-detection and removal path. Detection, the failure exit status, and partial in-file removal all behave the same as a single-process run.

This builds on @epenet's earlier attempt in #901, which was reverted because serializing the full report to disk on every run was too slow on large suites. The two changes that address that here:

- Transport is `config.workeroutput` (delivered over xdist's existing channel), not temp files and `json.dump`.
- The collected-item list, which is identical on every worker and is the large payload, is sent from a single worker (`gw0`) instead of once per worker.

The controller rebuilds just enough to reuse the normal logic: the snapshot collections, the per-location extension (so partial removal within a shared file works), the xfail count, and a stand-in for each collected item so `PyTestLocation` can resolve names.

## Related Issues

- Closes #535, unused snapshot detection disabled under pytest-xdist.
- Supersedes #901 by @epenet, same goal, with the performance issue that caused its revert addressed.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

New `tests/integration/test_snapshot_xdist.py` covers detection and partial removal under `-n 2`. Many integration tests previously marked `plugin_args_fails_xdist` now pass under xdist and were switched to `plugin_args`; three that fail for unrelated reasons (failure-diff output, `--pyargs` node selection, custom-comparator approximate match) are kept on the xfail fixture.

Two things worth a maintainer's eye:

- This is a behavior change: an xdist run with unused snapshots now fails (or deletes them under `--snapshot-update`), matching non-xdist behavior. Surfaced as a true positive, but it can turn a previously-green xdist suite red on upgrade.
- The collected-item list is sent from `gw0` only, which assumes default load scheduling. Reconstructed items also don't carry doctest state, so snapshotting inside doctests under xdist isn't covered.

@epenet, since this revives your #901 and the motivation was Home Assistant, could you sanity-check the performance side and whether the reporting semantics match what you needed?
