### PR TITLE
fix: Defer registering `pytest-xdist` hook `pytest_testnodedown` to avoid "unknown hook" error

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -227,7 +227,7 @@ class DeferXDist:
                 syrupy.add_worker_report(report)
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     if config.pluginmanager.hasplugin("xdist"):
         config.pluginmanager.register(DeferXDist())
 

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -210,18 +210,26 @@ def pytest_collection_finish(session: Any) -> None:
     session.config._syrupy.select_items(session.items)
 
 
-def pytest_testnodedown(node: Any, error: Any) -> None:
-    """
-    Collect a pytest-xdist worker's snapshot report as the worker shuts down.
-    Runs on the controller; the payload is published via ``config.workeroutput``.
-    https://pytest-xdist.readthedocs.io/en/stable/distribution.html
-    """
-    workeroutput = getattr(node, "workeroutput", None)
-    syrupy = getattr(node.config, "_syrupy", None)
-    if workeroutput and syrupy:
-        report = workeroutput.get("syrupy_report")
-        if report is not None:
-            syrupy.add_worker_report(report)
+class DeferXDist:
+    """Defer pytest-xdist hook functions."""
+
+    def pytest_testnodedown(self, node: Any, error: Any) -> None:
+        """
+        Collect a pytest-xdist worker's snapshot report as the worker shuts down.
+        Runs on the controller; the payload is published via ``config.workeroutput``.
+        https://pytest-xdist.readthedocs.io/en/stable/distribution.html
+        """
+        workeroutput = getattr(node, "workeroutput", None)
+        syrupy = getattr(node.config, "_syrupy", None)
+        if workeroutput and syrupy:
+            report = workeroutput.get("syrupy_report")
+            if report is not None:
+                syrupy.add_worker_report(report)
+
+
+def pytest_configure(config):
+    if config.pluginmanager.hasplugin("xdist"):
+        config.pluginmanager.register(DeferXDist())
 
 
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:

--- a/tests/integration/test_snapshot_xdist.py
+++ b/tests/integration/test_snapshot_xdist.py
@@ -54,3 +54,27 @@ def test_xdist_removes_unused(generated):
     assert "test_a[1]" in content
     assert "test_a[2]" not in content
     assert "test_a[3]" not in content
+
+
+def test_without_xdist_installed(testdir):
+    """
+    Registering the pytest-xdist hook `pytest_testnodedown` unconditionally
+    makes pytest raise a `PluginValidationError` when pytest-xdist is not
+    installed alongside syrupy, since pytest-xdist provides the hookspec that
+    hook implements.
+
+    Simulate pytest-xdist not being installed by disabling the plugin outright
+    with `-p no:xdist`.
+    """
+    testdir.makepyfile(
+        """
+        def test_a(snapshot):
+            assert 1 == snapshot
+        """
+    )
+
+    result = testdir.runpytest("-p", "no:xdist", "--snapshot-update")
+
+    assert result.ret == 0
+    result.stdout.no_fnmatch_line("*PluginValidationError*")
+    result.stdout.no_fnmatch_line("*unknown hook*")


### PR DESCRIPTION
## Description

<!-- Provide a description of what your PR introduces or changes. -->

Release 5.5.0 (specifically https://github.com/syrupy-project/syrupy/pull/1132) broke usage of syrupy _without_ `pytest-xdist`.

## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes #0, a short description of the linked issue.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [ ] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
