### PR TITLE
fix: Fix detecting `pytest-xdist` when loaded via `PYTEST_PLUGINS`

### DIFF
--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -228,7 +228,9 @@ class DeferXDist:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    if config.pluginmanager.hasplugin("xdist"):
+    if config.pluginmanager.hasplugin("xdist") or config.pluginmanager.hasplugin(
+        "xdist.plugin"
+    ):
         config.pluginmanager.register(DeferXDist())
 
 

--- a/tests/integration/test_snapshot_xdist.py
+++ b/tests/integration/test_snapshot_xdist.py
@@ -78,3 +78,37 @@ def test_without_xdist_installed(testdir):
     assert result.ret == 0
     result.stdout.no_fnmatch_line("*PluginValidationError*")
     result.stdout.no_fnmatch_line("*unknown hook*")
+
+
+def test_p_xdist(testdir, monkeypatch):
+    """Test detecting pytest-xdist registered via "-p xdist"."""
+    testdir.makepyfile(
+        """
+        def test_a(snapshot):
+            assert 1 == snapshot
+        """
+    )
+
+    monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+    monkeypatch.setenv("PYTEST_PLUGINS", "syrupy")
+    result = testdir.runpytest(
+        "-v", "-p", "xdist", "--numprocesses", "2", "--snapshot-update"
+    )
+    result.stdout.re_match_lines((r"1 snapshot generated",))
+    assert result.ret == 0
+
+
+def test_pytest_plugins_xdist(testdir, monkeypatch):
+    """Test detecting pytest-xdist registered via PYTEST_PLUGINS."""
+    testdir.makepyfile(
+        """
+        def test_a(snapshot):
+            assert 1 == snapshot
+        """
+    )
+
+    monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+    monkeypatch.setenv("PYTEST_PLUGINS", "syrupy,xdist.plugin")
+    result = testdir.runpytest("-v", "--numprocesses", "2", "--snapshot-update")
+    result.stdout.re_match_lines((r"1 snapshot generated",))
+    assert result.ret == 0


### PR DESCRIPTION
## Description

Fix the `pytest-xdist` detection code to support both `xdist` and `xdist.plugin` as registration names, in order to fix the detection when it is loaded via `PYTEST_PLUGINS` (which uses the latter name) rather than autoloading / `-p` (which uses the former).  Technically it could also be explicitly loaded using any other name, but covering these two common cases should be good enough for all the common workflows.

## Related Issues

Fixes #1141

## Checklist

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

I've added tests for two common cases: loading via `-p xdist` and via `PYTEST_PLUGINS`.