### PR TITLE
fix: make set/dict serialization deterministic for partial-order elements

### DIFF
--- a/src/syrupy/extensions/amber/serializer.py
+++ b/src/syrupy/extensions/amber/serializer.py
@@ -537,10 +537,17 @@ class AmberDataSerializer:
 
     @classmethod
     def sort(cls, iterable: Iterable[Any]) -> Iterable[Any]:
+        # Pre-sort by the serialized form so a natural ordering that is only
+        # partial keeps a deterministic order for incomparable elements. E.g.
+        # frozensets order by the subset relation, so two distinct frozensets
+        # where neither is a subset of the other compare as neither < nor >;
+        # the stable sort below would then leave them in hash-seeded set
+        # iteration order. Totally-ordered values keep their natural order.
+        values = sorted(iterable, key=cls._serialize)
         try:
-            return sorted(iterable)
+            return sorted(values)
         except TypeError:
-            return sorted(iterable, key=cls._serialize)
+            return values
 
     @classmethod
     def object_type(cls, data: "SerializableData") -> str:

--- a/tests/syrupy/extensions/amber/test_amber_serializer.py
+++ b/tests/syrupy/extensions/amber/test_amber_serializer.py
@@ -113,6 +113,20 @@ def test_set(snapshot, actual):
     assert snapshot == actual
 
 
+def test_sort_partial_order_is_deterministic():
+    # frozensets order by the subset relation, which is only a partial order:
+    # these three are pairwise incomparable (neither is a subset of another),
+    # so a plain sorted() leaves them in input order. sort() must normalize to
+    # a stable order regardless of input order, otherwise a set/dict of
+    # frozensets serializes differently across runs (hash-seeded iteration).
+    a = frozenset({"a", "b"})
+    b = frozenset({"a", "c"})
+    c = frozenset({"a", "d"})
+    assert list(AmberDataSerializer.sort([a, b, c])) == list(
+        AmberDataSerializer.sort([c, b, a])
+    )
+
+
 @pytest.mark.parametrize(
     "actual",
     [


### PR DESCRIPTION
## Summary

A `set` (or dict keyed) by `frozenset`s serializes non-deterministically — the order depends on `PYTHONHASHSEED`, so a snapshot recorded in one process can fail on a later run with no data change (a flaky snapshot, which is exactly what a snapshot library must never produce).

```python
from syrupy.extensions.amber.serializer import AmberDataSerializer as S
value = {frozenset({"a", "b"}), frozenset({"a", "c"}), frozenset({"a", "d"})}
# S.serialize(value) yields a different ordering under different PYTHONHASHSEED
```

## Cause

`AmberDataSerializer.sort` did `sorted(iterable)` and only fell back to the deterministic `key=cls._serialize` on `TypeError`. `frozenset` defines `__lt__` (the subset relation), so `sorted()` doesn't raise for a homogeneous set of frozensets — but subset order is only *partial*: two frozensets where neither is a subset of the other compare as neither `<` nor `>`, so the stable sort leaves them in set-iteration order, which is hash-seeded. The `TypeError` fallback never fires for this case.

## Fix

Pre-sort by the serialized form first. Because `sorted()` is stable, natural-order ties (partial-order incomparable elements) keep a deterministic order, while totally-ordered values (numbers, strings) still come out in their natural order — so existing snapshots don't drift — and unorderable/mixed types still fall through to the serialize-key order.

Verified deterministic across `PYTHONHASHSEED` 0–5; totally-ordered sets unchanged (`{2, 10, 1}` → `1, 2, 10`). The full test suite passes with no `.ambr` drift (464 passed, identical to `main`), and `ruff`/`mypy` are clean.

Added a regression test asserting `sort()` is invariant to input order for pairwise-incomparable frozensets (red before the fix, green after).

<!-- AI disclosure -->
*Prepared with AI assistance (Claude Code, Claude Opus 4.8). I reproduced the hash-seed non-determinism, verified the fix preserves natural ordering (no snapshot drift) against `main`, and reviewed the diff before opening.*
