### PR TITLE
fix: preserve skipped single-file snapshots

### DIFF
--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -249,6 +249,10 @@ class SnapshotReport:
                 mark_for_removal = (
                     snapshot_location not in self.used
                     and not unused_snapshot_collection.has_snapshots
+                    and not self._skipped_items_match_name(
+                        snapshot_location=snapshot_location,
+                        snapshot_name=Path(snapshot_location).stem,
+                    )
                 )
             else:
                 unused_snapshots = {

--- a/src/syrupy/report.py
+++ b/src/syrupy/report.py
@@ -246,7 +246,10 @@ class SnapshotReport:
                         snapshot_location=snapshot_location, snapshot_name=snapshot.name
                     )
                 }
-                mark_for_removal = snapshot_location not in self.used
+                mark_for_removal = (
+                    snapshot_location not in self.used
+                    and not unused_snapshot_collection.has_snapshots
+                )
             else:
                 unused_snapshots = {
                     snapshot

--- a/tests/integration/test_snapshot_skipped.py
+++ b/tests/integration/test_snapshot_skipped.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 
@@ -114,3 +116,52 @@ def test_skipped_single_file_snapshot(testdir, plugin_args):
 
     assert "snapshot unused" not in result.stdout.str()
     assert result.ret == 0
+
+
+def test_skipped_single_file_snapshot_with_other_extension(testdir, plugin_args):
+    test_file = testdir.makepyfile(
+        """
+        from syrupy.extensions.single_file import SingleFileSnapshotExtension
+
+        def test_used(snapshot):
+            assert snapshot == "used"
+
+        def test_single_file(snapshot):
+            assert snapshot.use_extension(SingleFileSnapshotExtension) == b"snapshot"
+        """
+    )
+    result = testdir.runpytest("--snapshot-update")
+    assert result.ret == 0
+    snapshot_file = (
+        Path(test_file).parent
+        / "__snapshots__"
+        / Path(test_file).stem
+        / "test_single_file.raw"
+    )
+    assert snapshot_file.exists()
+
+    testdir.makepyfile(
+        """
+        import pytest
+
+        from syrupy.extensions.single_file import SingleFileSnapshotExtension
+
+        def test_used(snapshot):
+            assert snapshot == "used"
+
+        @pytest.mark.skip
+        def test_single_file(snapshot):
+            assert snapshot.use_extension(SingleFileSnapshotExtension) == b"snapshot"
+        """
+    )
+    result = testdir.runpytest(*plugin_args)
+
+    assert "snapshot unused" not in result.stdout.str()
+    assert result.ret == 0
+    assert snapshot_file.exists()
+
+    result = testdir.runpytest("--snapshot-update", *plugin_args)
+
+    assert "unused snapshot deleted" not in result.stdout.str()
+    assert result.ret == 0
+    assert snapshot_file.exists()

--- a/tests/integration/test_snapshot_skipped.py
+++ b/tests/integration/test_snapshot_skipped.py
@@ -72,3 +72,45 @@ def test_skipped_snapshots_update(run_testcases, plugin_args):
     result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
     result.stdout.re_match_lines(r"1 snapshot passed\.$")
     assert result.ret == 0
+
+
+def test_skipped_single_file_snapshot(testdir, plugin_args):
+    testdir.makeconftest(
+        """
+        import pytest
+
+        from syrupy.extensions.single_file import SingleFileSnapshotExtension
+
+        @pytest.fixture
+        def snapshot(snapshot):
+            return snapshot.use_extension(SingleFileSnapshotExtension)
+        """
+    )
+    testdir.makepyfile(
+        """
+        def test_used(snapshot):
+            assert snapshot == b"used"
+
+        def test_single_file(snapshot):
+            assert snapshot == b"snapshot"
+        """
+    )
+    result = testdir.runpytest("--snapshot-update")
+    assert result.ret == 0
+
+    testdir.makepyfile(
+        """
+        import pytest
+
+        def test_used(snapshot):
+            assert snapshot == b"used"
+
+        @pytest.mark.skip
+        def test_single_file(snapshot):
+            assert snapshot == b"snapshot"
+        """
+    )
+    result = testdir.runpytest(*plugin_args)
+
+    assert "snapshot unused" not in result.stdout.str()
+    assert result.ret == 0


### PR DESCRIPTION
## Description

Fix false unused-snapshot reports affecting single-file snapshot extensions.

When one test runs while a sibling single-file snapshot test is skipped, Syrupy can discover the skipped snapshot either as a known collection or as an empty collection produced by another extension scanning the same snapshot directory. In the latter case, the report classified the file as an unknown collection even though its owning test was skipped.

The cleanup fallback now preserves known skipped collections as well as otherwise empty collections whose filename matches a skipped test. Genuine unknown or empty collections that do not belong to a skipped test remain eligible for removal.

This prevents false `snapshot unused` failures and preserves the skipped file when using `--snapshot-update`.

Regression coverage includes:

- pytest without xdist
- xdist with `-n0`
- xdist with `-n2`
- same-extension and mixed-extension discovery
- reporting and `--snapshot-update` cleanup

## Related Issues

No linked issue yet.

## Checklist

- [x] This PR has sufficient documentation
- [x] This PR has sufficient test coverage
- [x] The title follows the semantic convention

## Additional Comments

No additional comments.
