### PR TITLE
fix(matchers): replace values at nested paths in path_value default mode

### DIFF
--- a/src/syrupy/matchers.py
+++ b/src/syrupy/matchers.py
@@ -90,15 +90,20 @@ def path_value(
     Matches the path regex against the string repr of values for the types specified
     """
 
+    regex = kwargs.get("regex", False)
+    # path_type matches the path with _path_match, which escapes the key when
+    # regex is off, so the Match handed back carries the escaped pattern. Key
+    # the value lookup by that same form, or a path key with a regex-special
+    # char (e.g. the "." joining a nested path) never matches and the value is
+    # silently left unreplaced.
+    value_patterns = {(k if regex else re.escape(k)): v for k, v in mapping.items()}
     kwargs["mapping"] = dict.fromkeys(mapping, types)
     kwargs["replacer"] = lambda data, path_matches: (
         replacer(
             data,
-            _path_match(
-                str(data), mapping[path_matches.re.pattern], kwargs.get("regex", False)
-            ),
+            _path_match(str(data), value_patterns[path_matches.re.pattern], regex),
         )
-        if path_matches.re.pattern in mapping
+        if path_matches.re.pattern in value_patterns
         else data
     )
     return path_type(**kwargs)

--- a/tests/syrupy/extensions/amber/test_amber_matchers.py
+++ b/tests/syrupy/extensions/amber/test_amber_matchers.py
@@ -131,6 +131,27 @@ def test_regex_matcher_str_value(request, snapshot, tmp_path):
     assert actual == snapshot(matcher=my_matcher)
 
 
+def test_path_value_replaces_nested_value_in_literal_mode():
+    # regex=False (the default) must still replace values at nested paths, whose
+    # keys contain the "." path separator. The escaped path pattern used to miss
+    # the value lookup, silently leaving the value unreplaced in the snapshot.
+    def replacer(data, match):
+        return "REDACTED" if match else data
+
+    matcher = path_value(
+        {"user.token": "abc12345"},
+        types=(str,),
+        replacer=replacer,
+    )
+
+    serialized = AmberDataSerializer.serialize(
+        {"user": {"token": "abc12345"}}, matcher=matcher
+    )
+
+    assert "REDACTED" in serialized
+    assert "abc12345" not in serialized
+
+
 def test_multiple_matchers(snapshot):
     data = {"number": 1, "datetime": datetime.datetime.now(), "float": 1.3}
 


### PR DESCRIPTION
### Problem

`path_value` in its default mode (`regex=False`) never replaces a value whose path key contains a regex-special character — which is **every nested path**, since the `.` path separator is special:

```python
matcher = path_value({"user.token": "abc12345"}, types=(str,), replacer=redact)
# {"user": {"token": "abc12345"}} serializes with "abc12345" left in place;
# the identical matcher with regex=True redacts it.
```

`path_type` matches the path with `_path_match`, which `re.escape`s the key when `regex=False`, so the `re.Match` it hands to the replacer carries the *escaped* pattern (`user\.token`). The replacer then looks that escaped pattern up against the original, unescaped mapping keys (`user.token`), misses, and returns the value unchanged. For the redaction use case this feature exists for, the value silently leaks into the committed snapshot.

Top-level keys (no special char) and `regex=True` are unaffected, which is why the existing tests — all `regex=True` — didn't catch it.

### Fix

Key the value lookup by the same escaped form the path match used, so the lookup agrees with the pattern `path_type` produces.

### Tests

`test_path_value_replaces_nested_value_in_literal_mode` serializes a nested value with a default-mode `path_value` matcher and asserts it is replaced and does not leak; it fails before this change and passes after. The rest of `tests/syrupy/extensions/amber/` stays green (91 passed). `ruff check`, `ruff format`, and `mypy --strict src` pass.

---

*Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, wrote and ran the repro and the test, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*

