### PR TITLE
perf: compress xdist snapshot reports

### DIFF
--- a/src/syrupy/session.py
+++ b/src/syrupy/session.py
@@ -1,4 +1,6 @@
+import json
 import os
+import zlib
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import (
@@ -216,11 +218,13 @@ class SnapshotSession:
         output = getattr(self.pytest_session.config, "workeroutput", None)
         if output is None or self.report is None:
             return
+        collections = {
+            name: getattr(self.report, name).serialize() for name in _MERGED_COLLECTIONS
+        }
         payload: dict[str, Any] = {
-            "collections": {
-                name: getattr(self.report, name).serialize()
-                for name in _MERGED_COLLECTIONS
-            },
+            "collections": zlib.compress(
+                json.dumps(collections, separators=(",", ":")).encode()
+            ),
             "num_xfails": self.report._num_xfails,
             "selected": {
                 nodeid: status.value for nodeid, status in self._selected_items.items()
@@ -250,7 +254,12 @@ class SnapshotSession:
         selected: dict[str, ItemStatus] = {}
         for report in self._worker_reports:
             self.report._num_xfails += report["num_xfails"]
-            for name, serialized in report["collections"].items():
+            serialized_collections = report["collections"]
+            if isinstance(serialized_collections, bytes):
+                serialized_collections = json.loads(
+                    zlib.decompress(serialized_collections)
+                )
+            for name, serialized in serialized_collections.items():
                 getattr(self.report, name).merge_serialized(serialized)
             for nodeid, value in report["selected"].items():
                 status = ItemStatus(value)

--- a/tests/syrupy/test_session_xdist.py
+++ b/tests/syrupy/test_session_xdist.py
@@ -1,5 +1,7 @@
 """Unit tests for the pytest-xdist worker/controller report merging."""
 
+import json
+import zlib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -79,7 +81,9 @@ def test_worker_publishes_minimal_report(monkeypatch):
     worker._publish_worker_report()
 
     payload = worker.pytest_session.config.workeroutput["syrupy_report"]
-    assert payload["collections"]["used"] == {LOCATION: ["test_a"]}
+    assert isinstance(payload["collections"], bytes)
+    collections = json.loads(zlib.decompress(payload["collections"]))
+    assert collections["used"] == {LOCATION: ["test_a"]}
     assert payload["num_xfails"] == 2
     assert payload["selected"] == {"test_a.py::test_a": "passed"}
     assert payload["extensions"] == {
@@ -87,6 +91,46 @@ def test_worker_publishes_minimal_report(monkeypatch):
     }
     # gw0 is the only worker that ships the collected items.
     assert payload["collected"][0]["nodeid"] == "test_a.py::test_a"
+
+
+def test_worker_compresses_large_collection_report(monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw1")
+    worker = _session(workeroutput={})
+    assert worker.report is not None
+    names = [f"test_large_snapshot[{index}].{index}" for index in range(20_000)]
+    worker.report.discovered.update(_collection(*names))
+    worker.report.matched.update(_collection(*names))
+    worker.report.used.update(_collection(*names))
+
+    worker._publish_worker_report()
+
+    compressed = worker.pytest_session.config.workeroutput["syrupy_report"][
+        "collections"
+    ]
+    uncompressed = json.dumps(
+        {
+            name: getattr(worker.report, name).serialize()
+            for name in (
+                "discovered",
+                "created",
+                "failed",
+                "matched",
+                "updated",
+                "used",
+            )
+        },
+        separators=(",", ":"),
+    ).encode()
+    assert isinstance(compressed, bytes)
+    assert len(compressed) < len(uncompressed) // 5
+
+    controller = _session()
+    controller.add_worker_report(
+        worker.pytest_session.config.workeroutput["syrupy_report"]
+    )
+    controller._merge_worker_reports()
+    assert controller.report is not None
+    assert len(next(iter(controller.report.discovered))) == len(names)
 
 
 def test_worker_without_workeroutput_is_noop():


### PR DESCRIPTION
## Description

This compresses the snapshot collection portion of each pytest-xdist worker report before it is sent to the controller. The controller decompresses the payload before applying the existing merge logic, so unused-snapshot detection keeps receiving every worker's complete discovered, matched, and used collections.

For a synthetic report containing 200,000 snapshot names in the discovered, matched, and used collections, the transported collection payload drops from 21,533,460 bytes to 2,794,150 bytes (7.71x smaller). Compression took 0.347 seconds and decompression took 0.126 seconds in the local probe.

## Related Issues

- Fixes #1156, reduce the post-test xdist transfer overhead for very large snapshot collections.

## Checklist

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Validation

- `uv run pytest -q tests/syrupy/test_session_xdist.py tests/integration/test_snapshot_xdist.py` (12 passed)
- `uv run invoke lint` (mypy, Ruff, and Ruff format passed)
- `git diff --check upstream/main...HEAD`

The complete cross-platform test matrix is deferred to CI.
