### PR TITLE
feat: mark tests that use snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ pytest --snapshot-update
 
 A snapshot file should be generated under a `__snapshots__` directory in the same directory as `test_file.py`. The `__snapshots__` directory and all its children should be committed along with your test code.
 
+Syrupy automatically marks tests that directly or indirectly use the `snapshot`
+fixture with `syrupy_snapshot`. To update snapshots without running unrelated
+tests, combine the marker with the update option:
+
+```shell
+pytest --snapshot-update -m syrupy_snapshot
+```
+
 #### Usage in `unittest.TestCase` subclasses
 
 [Due to limitations in `unittest` and `pytest`](https://docs.pytest.org/en/9.0.x/how-to/unittest.html#pytest-features-in-unittest-testcase-subclasses), the `snapshot` fixture is not directly usable in `TestCase` subclasses (including Django's `TestCase`).

--- a/src/syrupy/__init__.py
+++ b/src/syrupy/__init__.py
@@ -192,6 +192,7 @@ def pytest_sessionstart(session: Any) -> None:
     session.config._syrupy.start()
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(
     session: Any, config: Any, items: list["pytest.Item"]
 ) -> None:
@@ -199,6 +200,9 @@ def pytest_collection_modifyitems(
     After tests are collected and before any modification is performed.
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_collection_modifyitems
     """
+    for item in items:
+        if "snapshot" in getattr(item, "fixturenames", ()):
+            item.add_marker("syrupy_snapshot")
     config._syrupy.collect_items(items)
 
 
@@ -228,6 +232,10 @@ class DeferXDist:
 
 
 def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "syrupy_snapshot: test directly or indirectly uses the snapshot fixture",
+    )
     if config.pluginmanager.hasplugin("xdist") or config.pluginmanager.hasplugin(
         "xdist.plugin"
     ):

--- a/tests/integration/test_snapshot_marker.py
+++ b/tests/integration/test_snapshot_marker.py
@@ -12,16 +12,17 @@ def test_marker_selects_direct_and_indirect_snapshot_tests(testdir, plugin_args)
     testdir.makepyfile(
         test_selection="""
             import pytest
+            from syrupy.extensions.json import JSONSnapshotExtension
 
             @pytest.fixture
-            def snapshot_wrapper(snapshot):
-                return snapshot
+            def snapshot_json(snapshot):
+                return snapshot.with_defaults(extension_class=JSONSnapshotExtension)
 
             def test_direct(snapshot):
                 assert snapshot == "direct"
 
-            def test_indirect(snapshot_wrapper):
-                assert snapshot_wrapper == "indirect"
+            def test_indirect(snapshot_json):
+                assert snapshot_json == {"value": "indirect"}
 
             def test_without_snapshot():
                 raise AssertionError("ordinary test should be deselected")
@@ -49,7 +50,14 @@ def test_marker_selects_direct_and_indirect_snapshot_tests(testdir, plugin_args)
     snapshot_file = Path(testdir.tmpdir, "__snapshots__", "test_selection.ambr")
     assert snapshot_file.exists()
     assert "direct" in snapshot_file.read_text()
-    assert "indirect" in snapshot_file.read_text()
+    json_snapshot_file = Path(
+        testdir.tmpdir,
+        "__snapshots__",
+        "test_selection",
+        "test_indirect.json",
+    )
+    assert json_snapshot_file.exists()
+    assert "indirect" in json_snapshot_file.read_text()
 
 
 def test_marker_combines_with_existing_mark_and_keyword_filters(testdir, plugin_args):

--- a/tests/integration/test_snapshot_marker.py
+++ b/tests/integration/test_snapshot_marker.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+
+
+def assert_marker_outcomes(result, plugin_args, *, passed, deselected):
+    if plugin_args == ["--numprocesses", "2"]:
+        result.assert_outcomes(passed=passed)
+    else:
+        result.assert_outcomes(passed=passed, deselected=deselected)
+
+
+def test_marker_selects_direct_and_indirect_snapshot_tests(testdir, plugin_args):
+    testdir.makepyfile(
+        test_selection="""
+            import pytest
+
+            @pytest.fixture
+            def snapshot_wrapper(snapshot):
+                return snapshot
+
+            def test_direct(snapshot):
+                assert snapshot == "direct"
+
+            def test_indirect(snapshot_wrapper):
+                assert snapshot_wrapper == "indirect"
+
+            def test_without_snapshot():
+                raise AssertionError("ordinary test should be deselected")
+        """
+    )
+    initial = testdir.runpytest(
+        "-v",
+        "--snapshot-update",
+        "test_selection.py::test_direct",
+        "test_selection.py::test_indirect",
+    )
+    initial.assert_outcomes(passed=2)
+
+    result = testdir.runpytest(
+        "-v",
+        "--strict-markers",
+        "--snapshot-update",
+        "-m",
+        "syrupy_snapshot",
+        *plugin_args,
+    )
+
+    assert_marker_outcomes(result, plugin_args, passed=2, deselected=1)
+    result.stdout.re_match_lines((r"2 snapshots passed\.",))
+    snapshot_file = Path(testdir.tmpdir, "__snapshots__", "test_selection.ambr")
+    assert snapshot_file.exists()
+    assert "direct" in snapshot_file.read_text()
+    assert "indirect" in snapshot_file.read_text()
+
+
+def test_marker_combines_with_existing_mark_and_keyword_filters(testdir, plugin_args):
+    testdir.makeini(
+        """
+        [pytest]
+        markers = selected: tests selected for this regression
+        """
+    )
+    testdir.makepyfile(
+        test_selection="""
+            import pytest
+
+            @pytest.mark.selected
+            def test_snapshot_selected(snapshot):
+                assert snapshot == "selected"
+
+            @pytest.mark.selected
+            def test_snapshot_other(snapshot):
+                raise AssertionError("filtered by -k")
+
+            @pytest.mark.selected
+            def test_ordinary_selected():
+                raise AssertionError("filtered by the Syrupy marker")
+        """
+    )
+
+    result = testdir.runpytest(
+        "-v",
+        "--snapshot-update",
+        "-m",
+        "syrupy_snapshot and selected",
+        "-k",
+        "snapshot_selected",
+        *plugin_args,
+    )
+
+    assert_marker_outcomes(result, plugin_args, passed=1, deselected=2)
+    result.stdout.re_match_lines((r"1 snapshot generated\.",))
+
+
+def test_marker_filter_does_not_delete_snapshot_for_keyword_deselected_test(
+    testdir, plugin_args
+):
+    testdir.makepyfile(
+        test_selection="""
+            def test_one(snapshot):
+                assert snapshot == "one"
+
+            def test_two(snapshot):
+                assert snapshot == "two"
+        """
+    )
+    initial = testdir.runpytest("-v", "--snapshot-update")
+    initial.assert_outcomes(passed=2)
+
+    result = testdir.runpytest(
+        "-v",
+        "--snapshot-update",
+        "-m",
+        "syrupy_snapshot",
+        "-k",
+        "test_one",
+        *plugin_args,
+    )
+
+    assert_marker_outcomes(result, plugin_args, passed=1, deselected=1)
+    output = result.stdout.str().lower()
+    assert "unused" not in output
+    assert "deleted" not in output
+    snapshot_file = Path(testdir.tmpdir, "__snapshots__", "test_selection.ambr")
+    assert "test_two" in snapshot_file.read_text()
+
+
+def test_snapshot_update_without_marker_filter_runs_ordinary_tests(
+    testdir, plugin_args
+):
+    testdir.makepyfile(
+        test_selection="""
+            def test_with_snapshot(snapshot):
+                assert snapshot == "snapshot"
+
+            def test_without_snapshot():
+                assert True
+        """
+    )
+
+    result = testdir.runpytest("-v", "--snapshot-update", *plugin_args)
+
+    result.assert_outcomes(passed=2)
+    assert "deselected" not in result.stdout.str()


### PR DESCRIPTION
## Description

Mark every test whose fixture closure includes Syrupy's `snapshot` fixture with `syrupy_snapshot`.

Users can update snapshots without running unrelated tests with:

```shell
pytest --snapshot-update -m syrupy_snapshot
```

- rely on pytest's built-in marker selection instead of maintaining separate selection logic
- cover direct and indirect snapshot fixture dependencies
- register the marker for strict marker validation
- preserve existing `--snapshot-update` behavior and snapshot cleanup bookkeeping when `-m` or `-k` deselects tests

## Related Issues

- Closes #922.

## Checklist

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic convention.

## Additional Comments

Validation:

- marker integration tests across serial, xdist disabled, and two xdist workers: 12 passed
- related update and unused-snapshot regressions: 64 passed, 2 xfailed
- full test suite: 487 passed, 5 xfailed, 6 xpassed
- Ruff check and format check passed for the changed Python files
- strict Mypy passed for `src` and `benchmarks`
- `git diff --check` passed